### PR TITLE
Fix ESM incompatibility in skills loader bin-requirements check (Issue #3)

### DIFF
--- a/src/skills/loader.ts
+++ b/src/skills/loader.ts
@@ -8,6 +8,7 @@
 
 import fs from "fs";
 import path from "path";
+import { execSync } from "child_process";
 import type { Skill, AutomatonDatabase } from "../types.js";
 import { parseSkillMd } from "./format.js";
 
@@ -72,7 +73,6 @@ function checkRequirements(skill: Skill): boolean {
   if (skill.requires.bins) {
     for (const bin of skill.requires.bins) {
       try {
-        const { execSync } = require("child_process");
         execSync(`which ${bin}`, { stdio: "ignore" });
       } catch {
         return false;


### PR DESCRIPTION
skills/loader.ts calls `require("child_process")` during requirements checks. In an ESM runtime (repo uses ESM-style imports everywhere) require is not defined- so bin requirements will silently fail and skills with requires.bins will never activate.



Fixes #3 