### PR TITLE
Wire heartbeat config into daemon scheduling (defaultIntervalMs / lowComputeMultiplier unused)

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -234,6 +234,7 @@ async function run(): Promise<void> {
   const heartbeat = createHeartbeatDaemon({
     identity,
     config,
+    heartbeatConfig,
     db,
     conway,
     social,


### PR DESCRIPTION
Closes #4 

Code changes made by me, however this description is generated:

<html><head></head><body><p>Here's a cleaned-up version for a GitHub PR description:</p>
<hr>
<h2>Summary</h2>
<p><code>heartbeat/config.ts</code> defines <code>defaultIntervalMs</code> (default 60s) and <code>lowComputeMultiplier</code> (default 4×), but <code>heartbeat/daemon.ts</code> never received or used them. The tick interval was hardcoded to <code>60_000</code> ms and the low-compute multiplier had no effect — only task filtering changed in low-compute mode, not scheduling frequency.</p>
<h2>Changes</h2>
<ul>
<li><strong><code>heartbeat/daemon.ts</code>:</strong> Add <code>heartbeatConfig: HeartbeatConfig</code> to <code>HeartbeatDaemonOptions</code>
<ul>
<li>Replace hardcoded <code>60_000</code> with <code>heartbeatConfig.defaultIntervalMs</code> in <code>start()</code></li>
<li>Add a <code>tickCount</code> counter; in low-compute mode, skip any tick where <code>tickCount % lowComputeMultiplier !== 0</code>, effectively stretching the interval by the configured multiplier without restarting the interval</li>
</ul>
</li>
<li><strong><code>src/index.ts</code>:</strong> Pass the already-loaded <code>heartbeatConfig</code> to <code>createHeartbeatDaemon</code></li>
</ul>
<h2>Behavior</h2>

Mode | Behavior
-- | --
Normal | Tick every defaultIntervalMs (60s by default — no change from current behavior)
Low-compute | Tasks only execute every 4th tick by default (240s effective interval), configurable via lowComputeMultiplier in heartbeat.yml
Debug (logLevel: debug) | Still uses the 15s override, unchanged

</body></html><html><head></head><body><p>Here's a cleaned-up version for a GitHub PR description:</p>
<hr>
<h2>Summary</h2>
<p><code>heartbeat/config.ts</code> defines <code>defaultIntervalMs</code> (default 60s) and <code>lowComputeMultiplier</code> (default 4×), but <code>heartbeat/daemon.ts</code> never received or used them. The tick interval was hardcoded to <code>60_000</code> ms and the low-compute multiplier had no effect — only task filtering changed in low-compute mode, not scheduling frequency.</p>
<h2>Changes</h2>
<ul>
<li><strong><code>heartbeat/daemon.ts</code>:</strong> Add <code>heartbeatConfig: HeartbeatConfig</code> to <code>HeartbeatDaemonOptions</code>
<ul>
<li>Replace hardcoded <code>60_000</code> with <code>heartbeatConfig.defaultIntervalMs</code> in <code>start()</code></li>
<li>Add a <code>tickCount</code> counter; in low-compute mode, skip any tick where <code>tickCount % lowComputeMultiplier !== 0</code>, effectively stretching the interval by the configured multiplier without restarting the interval</li>
</ul>
</li>
<li><strong><code>src/index.ts</code>:</strong> Pass the already-loaded <code>heartbeatConfig</code> to <code>createHeartbeatDaemon</code></li>
</ul>
<h2>Behavior</h2>

Mode | Behavior
-- | --
Normal | Tick every defaultIntervalMs (60s by default — no change from current behavior)
Low-compute | Tasks only execute every 4th tick by default (240s effective interval), configurable via lowComputeMultiplier in heartbeat.yml
Debug (logLevel: debug) | Still uses the 15s override, unchanged

</body></html>