### PR TITLE
Filter out sandbox-dependent tools when no sandbox is provisioned

### DIFF
--- a/src/agent/tools.ts
+++ b/src/agent/tools.ts
@@ -67,13 +67,14 @@ function isForbiddenCommand(command: string, sandboxId: string): string | null {
 // ─── Built-in Tools ────────────────────────────────────────────
 
 export function createBuiltinTools(sandboxId: string): AutomatonTool[] {
-  return [
+  const allTools: AutomatonTool[] = [
     // ── VM/Sandbox Tools ──
     {
       name: "exec",
       description:
         "Execute a shell command in your sandbox. Returns stdout, stderr, and exit code.",
       category: "vm",
+      requiresSandbox: true,
       parameters: {
         type: "object",
         properties: {
@@ -104,6 +105,7 @@ export function createBuiltinTools(sandboxId: string): AutomatonTool[] {
       name: "write_file",
       description: "Write content to a file in your sandbox.",
       category: "vm",
+      requiresSandbox: true,
       parameters: {
         type: "object",
         properties: {
@@ -129,6 +131,7 @@ export function createBuiltinTools(sandboxId: string): AutomatonTool[] {
       name: "read_file",
       description: "Read content from a file in your sandbox.",
       category: "vm",
+      requiresSandbox: true,
       parameters: {
         type: "object",
         properties: {
@@ -145,6 +148,7 @@ export function createBuiltinTools(sandboxId: string): AutomatonTool[] {
       description:
         "Expose a port from your sandbox to the internet. Returns a public URL.",
       category: "vm",
+      requiresSandbox: true,
       parameters: {
         type: "object",
         properties: {
@@ -161,6 +165,7 @@ export function createBuiltinTools(sandboxId: string): AutomatonTool[] {
       name: "remove_port",
       description: "Remove a previously exposed port.",
       category: "vm",
+      requiresSandbox: true,
       parameters: {
         type: "object",
         properties: {
@@ -275,6 +280,7 @@ export function createBuiltinTools(sandboxId: string): AutomatonTool[] {
         "Edit a file in your own codebase. Changes are audited, rate-limited, and safety-checked. Some files are protected.",
       category: "self_mod",
       dangerous: true,
+      requiresSandbox: true,
       parameters: {
         type: "object",
         properties: {
@@ -317,6 +323,7 @@ export function createBuiltinTools(sandboxId: string): AutomatonTool[] {
       name: "install_npm_package",
       description: "Install an npm package in your environment.",
       category: "self_mod",
+      requiresSandbox: true,
       parameters: {
         type: "object",
         properties: {
@@ -671,6 +678,7 @@ Model: ${ctx.inference.getDefaultModel()}
       name: "install_mcp_server",
       description: "Install an MCP server to extend your capabilities.",
       category: "self_mod",
+      requiresSandbox: true,
       parameters: {
         type: "object",
         properties: {
@@ -761,6 +769,7 @@ Model: ${ctx.inference.getDefaultModel()}
       name: "install_skill",
       description: "Install a skill from a git repo, URL, or create one.",
       category: "skills",
+      requiresSandbox: true,
       parameters: {
         type: "object",
         properties: {
@@ -828,6 +837,7 @@ Model: ${ctx.inference.getDefaultModel()}
       name: "create_skill",
       description: "Create a new skill by writing a SKILL.md file.",
       category: "skills",
+      requiresSandbox: true,
       parameters: {
         type: "object",
         properties: {
@@ -854,6 +864,7 @@ Model: ${ctx.inference.getDefaultModel()}
       name: "remove_skill",
       description: "Remove (disable) an installed skill.",
       category: "skills",
+      requiresSandbox: true,
       parameters: {
         type: "object",
         properties: {
@@ -880,6 +891,7 @@ Model: ${ctx.inference.getDefaultModel()}
       name: "git_status",
       description: "Show git status for a repository.",
       category: "git",
+      requiresSandbox: true,
       parameters: {
         type: "object",
         properties: {
@@ -897,6 +909,7 @@ Model: ${ctx.inference.getDefaultModel()}
       name: "git_diff",
       description: "Show git diff for a repository.",
       category: "git",
+      requiresSandbox: true,
       parameters: {
         type: "object",
         properties: {
@@ -914,6 +927,7 @@ Model: ${ctx.inference.getDefaultModel()}
       name: "git_commit",
       description: "Create a git commit.",
       category: "git",
+      requiresSandbox: true,
       parameters: {
         type: "object",
         properties: {
@@ -933,6 +947,7 @@ Model: ${ctx.inference.getDefaultModel()}
       name: "git_log",
       description: "View git commit history.",
       category: "git",
+      requiresSandbox: true,
       parameters: {
         type: "object",
         properties: {
@@ -952,6 +967,7 @@ Model: ${ctx.inference.getDefaultModel()}
       name: "git_push",
       description: "Push to a git remote.",
       category: "git",
+      requiresSandbox: true,
       parameters: {
         type: "object",
         properties: {
@@ -975,6 +991,7 @@ Model: ${ctx.inference.getDefaultModel()}
       name: "git_branch",
       description: "Manage git branches (list, create, checkout, delete).",
       category: "git",
+      requiresSandbox: true,
       parameters: {
         type: "object",
         properties: {
@@ -998,6 +1015,7 @@ Model: ${ctx.inference.getDefaultModel()}
       name: "git_clone",
       description: "Clone a git repository.",
       category: "git",
+      requiresSandbox: true,
       parameters: {
         type: "object",
         properties: {
@@ -1047,6 +1065,7 @@ Model: ${ctx.inference.getDefaultModel()}
       name: "update_agent_card",
       description: "Generate and save an updated agent card.",
       category: "registry",
+      requiresSandbox: true,
       parameters: { type: "object", properties: {} },
       execute: async (_args, ctx) => {
         const { generateAgentCard, saveAgentCard } = await import("../registry/agent-card.js");
@@ -1502,6 +1521,13 @@ Model: ${ctx.inference.getDefaultModel()}
       },
     },
   ];
+
+  // Omit sandbox-dependent tools when no sandbox is provisioned
+  if (!sandboxId) {
+    return allTools.filter((t) => !t.requiresSandbox);
+  }
+
+  return allTools;
 }
 
 /**

--- a/src/types.ts
+++ b/src/types.ts
@@ -124,6 +124,7 @@ export interface AutomatonTool {
   ) => Promise<string>;
   dangerous?: boolean;
   category: ToolCategory;
+  requiresSandbox?: boolean;
 }
 
 export type ToolCategory =


### PR DESCRIPTION
## Problem

When `sandboxId` is empty (e.g. Conway Cloud at capacity), all 49 tools are sent to the LLM every turn — including 19 that will always fail with `404: POST /v1/sandboxes//exec`. The agent wastes credits calling tools like `exec`, `git_log`, and `edit_own_file` that can never succeed, and the tool schemas inflate every prompt unnecessarily.

## Solution

Add an optional `requiresSandbox` field to `AutomatonTool` and tag the 19 tools that depend on a provisioned sandbox. When `sandboxId` is empty, these tools are filtered out of the list before it reaches the inference client.

**49 → 30 tools** when no sandbox is available.

### Tools filtered (19):

| Category | Tools |
|---|---|
| vm | `exec`, `write_file`, `read_file`, `expose_port`, `remove_port` |
| git | `git_status`, `git_diff`, `git_commit`, `git_log`, `git_push`, `git_branch`, `git_clone` |
| self_mod | `edit_own_file`, `install_npm_package`, `install_mcp_server` |
| skills | `install_skill`, `create_skill`, `remove_skill` |
| registry | `update_agent_card` |

### Tools kept (30):

All tools that use top-level Conway API endpoints (`/v1/credits/*`, `/v1/domains/*`), on-chain operations (ERC-8004, USDC balance), local operations (`review_upstream_changes`, `pull_upstream`, `modify_heartbeat`), social relay, or replication (which creates/targets *child* sandboxes, not the parent's).

Every tool was individually audited by tracing its execution path through `conway.exec`, `conway.writeFile`, `conway.readFile`, `conway.exposePort`, `conway.removePort` and their transitive dependencies in `self-mod/code.ts`, `git/tools.ts`, `registry/agent-card.ts`, and `skills/registry.ts`.

## Impact

- Fewer tokens per inference call → lower credit burn per turn
- No more wasted turns on guaranteed-404 tool calls
- Zero behavior change when a sandbox *is* provisioned (all 49 tools available)
- All existing tests pass (tests use `sandboxId: "test-sandbox-id"`, so no filtering applies)

## Changes

- `src/types.ts`: Add optional `requiresSandbox?: boolean` to `AutomatonTool`
- `src/agent/tools.ts`: Tag 19 tools, filter when `sandboxId` is empty