### PR TITLE
feat: add SAID Protocol cross-chain identity integration (Solana)

### DIFF
--- a/src/registry/said.ts
+++ b/src/registry/said.ts
@@ -1,0 +1,110 @@
+/**
+ * SAID Protocol Integration
+ *
+ * Registers the automaton with SAID Protocol — on-chain identity for AI agents on Solana.
+ * This gives Conway automatons cross-chain identity: Base (ERC-8004) + Solana (SAID).
+ *
+ * SAID Protocol: https://saidprotocol.com
+ * Docs: https://saidprotocol.com/docs.html
+ *
+ * Registration is free (off-chain pending). On-chain verification costs ~$0.50 in SOL.
+ * Agents registered with SAID appear in the public agent directory at saidprotocol.com/agents
+ */
+
+const SAID_API = "https://api.saidprotocol.com";
+
+export interface SAIDRegistration {
+  wallet: string;
+  name: string;
+  saidProfileUrl: string;
+  registeredAt: string;
+}
+
+export interface SAIDOptions {
+  /** Solana wallet address (public key). Required. */
+  wallet: string;
+  /** Agent name */
+  name: string;
+  /** Short description of what the agent does */
+  description?: string;
+  /** Twitter/X handle (without @) */
+  twitter?: string;
+  /** Website URL */
+  website?: string;
+  /** Skills or capabilities this agent has */
+  skills?: string[];
+  /** MCP or A2A endpoint URL if the agent exposes one */
+  mcpEndpoint?: string;
+}
+
+/**
+ * Register this automaton with SAID Protocol.
+ *
+ * Creates a free off-chain pending identity. The agent will appear in
+ * the SAID directory at saidprotocol.com/agents/<wallet>.
+ *
+ * On-chain verification (optional) requires ~0.01 SOL and proves the
+ * entity is a genuine running AI agent via challenge-response.
+ */
+export async function registerWithSAID(
+  options: SAIDOptions
+): Promise<SAIDRegistration> {
+  const { wallet, name, description, twitter, website, skills, mcpEndpoint } =
+    options;
+
+  const payload: Record<string, unknown> = {
+    wallet,
+    name,
+    ...(description && { description }),
+    ...(twitter && { twitter }),
+    ...(website && { website }),
+    ...(skills && skills.length > 0 && { capabilities: skills }),
+    ...(mcpEndpoint && { mcpEndpoint }),
+    source: "automaton",
+  };
+
+  const res = await fetch(`${SAID_API}/api/register/pending`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(payload),
+  });
+
+  if (!res.ok) {
+    const err = await res.json().catch(() => ({}));
+    throw new Error(
+      `SAID registration failed: ${(err as { error?: string }).error || res.statusText}`
+    );
+  }
+
+  const data = (await res.json()) as { wallet?: string };
+  const registeredWallet = data.wallet || wallet;
+
+  return {
+    wallet: registeredWallet,
+    name,
+    saidProfileUrl: `https://saidprotocol.com/agents/${registeredWallet}`,
+    registeredAt: new Date().toISOString(),
+  };
+}
+
+/**
+ * Check if a wallet is already registered with SAID Protocol.
+ */
+export async function checkSAIDRegistration(
+  wallet: string
+): Promise<{ registered: boolean; verified: boolean; profileUrl: string }> {
+  try {
+    const res = await fetch(`${SAID_API}/api/agents/${wallet}`);
+    if (res.ok) {
+      const agent = (await res.json()) as { isVerified?: boolean };
+      return {
+        registered: true,
+        verified: agent.isVerified || false,
+        profileUrl: `https://saidprotocol.com/agents/${wallet}`,
+      };
+    }
+    return { registered: false, verified: false, profileUrl: "" };
+  } catch {
+    return { registered: false, verified: false, profileUrl: "" };
+  }
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -34,6 +34,8 @@ export interface ProvisionResult {
 export interface AutomatonConfig {
   name: string;
   genesisPrompt: string;
+  /** Solana wallet address registered with SAID Protocol (auto-generated on first boot) */
+  saidWallet?: string;
   creatorMessage?: string;
   creatorAddress: Address;
   registeredWithConway: boolean;
@@ -579,6 +581,12 @@ export interface AgentCard {
   x402Support: boolean;
   active: boolean;
   parentAgent?: string;
+  /** SAID Protocol cross-chain identity on Solana (optional) */
+  said?: {
+    wallet: string;
+    profileUrl: string;
+    verified: boolean;
+  };
 }
 
 export interface AgentService {


### PR DESCRIPTION
## What this does

Adds optional [SAID Protocol](https://saidprotocol.com) integration — on-chain AI agent identity on Solana.

Conway automatons already have identity on Base via ERC-8004. This PR adds an optional second identity layer on Solana, giving agents **cross-chain identity** discoverable by both Ethereum and Solana ecosystems.

## Changes

- `src/registry/said.ts` — new module: register with SAID, check registration status
- `src/types.ts` — adds optional `said` field to `AgentCard` interface  
- `src/registry/agent-card.ts` — includes SAID data in agent card when a Solana wallet is provided

## Usage

```ts
import { registerWithSAID } from './registry/said.js';

const registration = await registerWithSAID({
  wallet: '<solana-pubkey>',
  name: config.name,
  description: 'Conway automaton — self-replicating sovereign AI',
  skills: ['self-modification', 'replication', 'code-execution'],
  mcpEndpoint: sandboxUrl,
});
// registration.saidProfileUrl → https://saidprotocol.com/agents/<wallet>
```

The agent card automatically includes SAID identity when `saidWallet` is passed to `generateAgentCard()`.

## Why

- **Free registration** — off-chain pending, no SOL required
- **Non-breaking** — fully opt-in, zero impact on existing behaviour
- **Cross-chain discoverability** — Conway agents appear in the SAID agent directory at [saidprotocol.com/agents](https://saidprotocol.com/agents)
- **On-chain verification available** — ~0.01 SOL upgrades to a cryptographically verified badge via challenge-response (proves the entity is a running agent, not a human)

SAID Protocol: [saidprotocol.com](https://saidprotocol.com) | [Docs](https://saidprotocol.com/docs.html)