### PR TITLE
Show full address in funding panel for easy copying

### DIFF
--- a/src/setup/wizard.ts
+++ b/src/setup/wizard.ts
@@ -128,14 +128,13 @@ export async function runSetupWizard(): Promise<AutomatonConfig> {
 }
 
 function showFundingPanel(address: string): void {
-  const short = `${address.slice(0, 6)}...${address.slice(-5)}`;
   const w = 58;
   const pad = (s: string, len: number) => s + " ".repeat(Math.max(0, len - s.length));
 
   console.log(chalk.cyan(`  ${"╭" + "─".repeat(w) + "╮"}`));
   console.log(chalk.cyan(`  │${pad("  Fund your automaton", w)}│`));
   console.log(chalk.cyan(`  │${" ".repeat(w)}│`));
-  console.log(chalk.cyan(`  │${pad(`  Address: ${short}`, w)}│`));
+  console.log(chalk.cyan(`  │${pad(`  Address: ${address}`, w)}│`));
   console.log(chalk.cyan(`  │${" ".repeat(w)}│`));
   console.log(chalk.cyan(`  │${pad("  1. Transfer Conway credits", w)}│`));
   console.log(chalk.cyan(`  │${pad("     conway credits transfer <address> <amount>", w)}│`));


### PR DESCRIPTION
The address to fund is sliced and cannot be copied, I changed it so that it shows the full address

Before:
<img width="424" height="224" alt="Screenshot 2026-02-18 at 15 02 26" src="https://github.com/user-attachments/assets/5957ae74-5763-4e13-88a6-5beb47922c45" />

After
<img width="422" height="224" alt="Screenshot 2026-02-18 at 15 59 04" src="https://github.com/user-attachments/assets/6646d9eb-6669-4639-8cd0-8315443da391" />

