### PR TITLE
feat(setup): add optional OpenAI/Anthropic BYOK with Conway fallback

### DIFF
--- a/packages/cli/src/runtime-shims.d.ts
+++ b/packages/cli/src/runtime-shims.d.ts
@@ -8,6 +8,8 @@ declare module "@conway/automaton/config.js" {
     inferenceModel: string;
     conwayApiUrl: string;
     conwayApiKey: string;
+    openaiApiKey?: string;
+    anthropicApiKey?: string;
     socialRelayUrl?: string;
   }
 

--- a/src/config.ts
+++ b/src/config.ts
@@ -79,6 +79,8 @@ export function createConfig(params: {
   sandboxId: string;
   walletAddress: Address;
   apiKey: string;
+  openaiApiKey?: string;
+  anthropicApiKey?: string;
   parentAddress?: Address;
 }): AutomatonConfig {
   return {
@@ -91,6 +93,8 @@ export function createConfig(params: {
     conwayApiUrl:
       DEFAULT_CONFIG.conwayApiUrl || "https://api.conway.tech",
     conwayApiKey: params.apiKey,
+    openaiApiKey: params.openaiApiKey,
+    anthropicApiKey: params.anthropicApiKey,
     inferenceModel: DEFAULT_CONFIG.inferenceModel || "gpt-4o",
     maxTokensPerTurn: DEFAULT_CONFIG.maxTokensPerTurn || 4096,
     heartbeatConfigPath:

--- a/src/conway/inference.ts
+++ b/src/conway/inference.ts
@@ -21,12 +21,16 @@ interface InferenceClientOptions {
   defaultModel: string;
   maxTokens: number;
   lowComputeModel?: string;
+  openaiApiKey?: string;
+  anthropicApiKey?: string;
 }
+
+type InferenceBackend = "conway" | "openai" | "anthropic";
 
 export function createInferenceClient(
   options: InferenceClientOptions,
 ): InferenceClient {
-  const { apiUrl, apiKey } = options;
+  const { apiUrl, apiKey, openaiApiKey, anthropicApiKey } = options;
   let currentModel = options.defaultModel;
   let maxTokens = options.maxTokens;
 
@@ -62,58 +66,34 @@ export function createInferenceClient(
       body.tool_choice = "auto";
     }
 
-    const resp = await fetch(`${apiUrl}/v1/chat/completions`, {
-      method: "POST",
-      headers: {
-        "Content-Type": "application/json",
-        Authorization: apiKey,
-      },
-      body: JSON.stringify(body),
+    const backend = resolveInferenceBackend(model, {
+      openaiApiKey,
+      anthropicApiKey,
     });
 
-    if (!resp.ok) {
-      const text = await resp.text();
-      throw new Error(
-        `Inference error: ${resp.status}: ${text}`,
-      );
+    if (backend === "anthropic") {
+      return chatViaAnthropic({
+        model,
+        tokenLimit,
+        messages,
+        tools,
+        temperature: opts?.temperature,
+        anthropicApiKey: anthropicApiKey as string,
+      });
     }
 
-    const data = await resp.json() as any;
-    const choice = data.choices?.[0];
+    const openAiLikeApiUrl =
+      backend === "openai" ? "https://api.openai.com" : apiUrl;
+    const openAiLikeApiKey =
+      backend === "openai" ? (openaiApiKey as string) : apiKey;
 
-    if (!choice) {
-      throw new Error("No completion choice returned from inference");
-    }
-
-    const message = choice.message;
-    const usage: TokenUsage = {
-      promptTokens: data.usage?.prompt_tokens || 0,
-      completionTokens: data.usage?.completion_tokens || 0,
-      totalTokens: data.usage?.total_tokens || 0,
-    };
-
-    const toolCalls: InferenceToolCall[] | undefined =
-      message.tool_calls?.map((tc: any) => ({
-        id: tc.id,
-        type: "function" as const,
-        function: {
-          name: tc.function.name,
-          arguments: tc.function.arguments,
-        },
-      }));
-
-    return {
-      id: data.id || "",
-      model: data.model || model,
-      message: {
-        role: message.role,
-        content: message.content || "",
-        tool_calls: toolCalls,
-      },
-      toolCalls,
-      usage,
-      finishReason: choice.finish_reason || "stop",
-    };
+    return chatViaOpenAiCompatible({
+      model,
+      body,
+      apiUrl: openAiLikeApiUrl,
+      apiKey: openAiLikeApiKey,
+      backend,
+    });
   };
 
   const setLowComputeMode = (enabled: boolean): void => {
@@ -150,4 +130,263 @@ function formatMessage(
   if (msg.tool_call_id) formatted.tool_call_id = msg.tool_call_id;
 
   return formatted;
+}
+
+function resolveInferenceBackend(
+  model: string,
+  keys: {
+    openaiApiKey?: string;
+    anthropicApiKey?: string;
+  },
+): InferenceBackend {
+  if (keys.anthropicApiKey && /^claude/i.test(model)) {
+    return "anthropic";
+  }
+  if (keys.openaiApiKey && /^(gpt|o[1-9]|chatgpt)/i.test(model)) {
+    return "openai";
+  }
+  return "conway";
+}
+
+async function chatViaOpenAiCompatible(params: {
+  model: string;
+  body: Record<string, unknown>;
+  apiUrl: string;
+  apiKey: string;
+  backend: "conway" | "openai";
+}): Promise<InferenceResponse> {
+  const resp = await fetch(`${params.apiUrl}/v1/chat/completions`, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      Authorization:
+        params.backend === "openai"
+          ? `Bearer ${params.apiKey}`
+          : params.apiKey,
+    },
+    body: JSON.stringify(params.body),
+  });
+
+  if (!resp.ok) {
+    const text = await resp.text();
+    throw new Error(
+      `Inference error (${params.backend}): ${resp.status}: ${text}`,
+    );
+  }
+
+  const data = await resp.json() as any;
+  const choice = data.choices?.[0];
+
+  if (!choice) {
+    throw new Error("No completion choice returned from inference");
+  }
+
+  const message = choice.message;
+  const usage: TokenUsage = {
+    promptTokens: data.usage?.prompt_tokens || 0,
+    completionTokens: data.usage?.completion_tokens || 0,
+    totalTokens: data.usage?.total_tokens || 0,
+  };
+
+  const toolCalls: InferenceToolCall[] | undefined =
+    message.tool_calls?.map((tc: any) => ({
+      id: tc.id,
+      type: "function" as const,
+      function: {
+        name: tc.function.name,
+        arguments: tc.function.arguments,
+      },
+    }));
+
+  return {
+    id: data.id || "",
+    model: data.model || params.model,
+    message: {
+      role: message.role,
+      content: message.content || "",
+      tool_calls: toolCalls,
+    },
+    toolCalls,
+    usage,
+    finishReason: choice.finish_reason || "stop",
+  };
+}
+
+async function chatViaAnthropic(params: {
+  model: string;
+  tokenLimit: number;
+  messages: ChatMessage[];
+  tools?: InferenceToolDefinition[];
+  temperature?: number;
+  anthropicApiKey: string;
+}): Promise<InferenceResponse> {
+  const transformed = transformMessagesForAnthropic(params.messages);
+  const body: Record<string, unknown> = {
+    model: params.model,
+    max_tokens: params.tokenLimit,
+    messages:
+      transformed.messages.length > 0
+        ? transformed.messages
+        : [{ role: "user", content: "Continue." }],
+  };
+
+  if (transformed.system) {
+    body.system = transformed.system;
+  }
+
+  if (params.temperature !== undefined) {
+    body.temperature = params.temperature;
+  }
+
+  if (params.tools && params.tools.length > 0) {
+    body.tools = params.tools.map((tool) => ({
+      name: tool.function.name,
+      description: tool.function.description,
+      input_schema: tool.function.parameters,
+    }));
+    body.tool_choice = { type: "auto" };
+  }
+
+  const resp = await fetch("https://api.anthropic.com/v1/messages", {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      "x-api-key": params.anthropicApiKey,
+      "anthropic-version": "2023-06-01",
+    },
+    body: JSON.stringify(body),
+  });
+
+  if (!resp.ok) {
+    const text = await resp.text();
+    throw new Error(`Inference error (anthropic): ${resp.status}: ${text}`);
+  }
+
+  const data = await resp.json() as any;
+  const content = Array.isArray(data.content) ? data.content : [];
+  const textBlocks = content.filter((c: any) => c?.type === "text");
+  const toolUseBlocks = content.filter((c: any) => c?.type === "tool_use");
+
+  const toolCalls: InferenceToolCall[] | undefined =
+    toolUseBlocks.length > 0
+      ? toolUseBlocks.map((tool: any) => ({
+          id: tool.id,
+          type: "function" as const,
+          function: {
+            name: tool.name,
+            arguments: JSON.stringify(tool.input || {}),
+          },
+        }))
+      : undefined;
+
+  const textContent = textBlocks
+    .map((block: any) => String(block.text || ""))
+    .join("\n")
+    .trim();
+
+  if (!textContent && !toolCalls?.length) {
+    throw new Error("No completion content returned from anthropic inference");
+  }
+
+  const promptTokens = data.usage?.input_tokens || 0;
+  const completionTokens = data.usage?.output_tokens || 0;
+  const usage: TokenUsage = {
+    promptTokens,
+    completionTokens,
+    totalTokens: promptTokens + completionTokens,
+  };
+
+  return {
+    id: data.id || "",
+    model: data.model || params.model,
+    message: {
+      role: "assistant",
+      content: textContent,
+      tool_calls: toolCalls,
+    },
+    toolCalls,
+    usage,
+    finishReason: normalizeAnthropicFinishReason(data.stop_reason),
+  };
+}
+
+function transformMessagesForAnthropic(
+  messages: ChatMessage[],
+): { system?: string; messages: Array<Record<string, unknown>> } {
+  const systemParts: string[] = [];
+  const transformed: Array<Record<string, unknown>> = [];
+
+  for (const msg of messages) {
+    if (msg.role === "system") {
+      if (msg.content) systemParts.push(msg.content);
+      continue;
+    }
+
+    if (msg.role === "user") {
+      transformed.push({
+        role: "user",
+        content: msg.content,
+      });
+      continue;
+    }
+
+    if (msg.role === "assistant") {
+      const content: Array<Record<string, unknown>> = [];
+      if (msg.content) {
+        content.push({ type: "text", text: msg.content });
+      }
+      for (const toolCall of msg.tool_calls || []) {
+        content.push({
+          type: "tool_use",
+          id: toolCall.id,
+          name: toolCall.function.name,
+          input: parseToolArguments(toolCall.function.arguments),
+        });
+      }
+      if (content.length === 0) {
+        content.push({ type: "text", text: "" });
+      }
+      transformed.push({
+        role: "assistant",
+        content,
+      });
+      continue;
+    }
+
+    if (msg.role === "tool") {
+      transformed.push({
+        role: "user",
+        content: [
+          {
+            type: "tool_result",
+            tool_use_id: msg.tool_call_id || "unknown_tool_call",
+            content: msg.content,
+          },
+        ],
+      });
+    }
+  }
+
+  return {
+    system: systemParts.length > 0 ? systemParts.join("\n\n") : undefined,
+    messages: transformed,
+  };
+}
+
+function parseToolArguments(raw: string): Record<string, unknown> {
+  try {
+    const parsed = JSON.parse(raw);
+    if (parsed && typeof parsed === "object" && !Array.isArray(parsed)) {
+      return parsed as Record<string, unknown>;
+    }
+    return { value: parsed };
+  } catch {
+    return { _raw: raw };
+  }
+}
+
+function normalizeAnthropicFinishReason(reason: unknown): string {
+  if (typeof reason !== "string") return "stop";
+  if (reason === "tool_use") return "tool_calls";
+  return reason;
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -198,6 +198,8 @@ async function run(): Promise<void> {
     apiKey,
     defaultModel: config.inferenceModel,
     maxTokens: config.maxTokensPerTurn,
+    openaiApiKey: config.openaiApiKey,
+    anthropicApiKey: config.anthropicApiKey,
   });
 
   // Create social client

--- a/src/setup/prompts.ts
+++ b/src/setup/prompts.ts
@@ -27,6 +27,10 @@ export async function promptRequired(label: string): Promise<string> {
   }
 }
 
+export async function promptOptional(label: string): Promise<string> {
+  return ask(chalk.white(`  → ${label}: `));
+}
+
 export async function promptMultiline(label: string): Promise<string> {
   console.log("");
   console.log(chalk.white(`  ${label}`));

--- a/src/types.ts
+++ b/src/types.ts
@@ -40,6 +40,8 @@ export interface AutomatonConfig {
   sandboxId: string;
   conwayApiUrl: string;
   conwayApiKey: string;
+  openaiApiKey?: string;
+  anthropicApiKey?: string;
   inferenceModel: string;
   maxTokensPerTurn: number;
   heartbeatConfigPath: string;


### PR DESCRIPTION
- add optional setup prompts for OpenAI and Anthropic API keys from human creators

- persist optional provider keys in config and runtime shims

- route inference to Anthropic/OpenAI when matching key+model is configured

- keep Conway inference as default when keys are skipped