### PR TITLE
fix(setup): show full address in funding panel

### DIFF
--- a/src/setup/wizard.ts
+++ b/src/setup/wizard.ts
@@ -157,14 +157,13 @@ export async function runSetupWizard(): Promise<AutomatonConfig> {
 }
 
 function showFundingPanel(address: string): void {
-  const short = `${address.slice(0, 6)}...${address.slice(-5)}`;
   const w = 58;
   const pad = (s: string, len: number) => s + " ".repeat(Math.max(0, len - s.length));
 
   console.log(chalk.cyan(`  ${"╭" + "─".repeat(w) + "╮"}`));
   console.log(chalk.cyan(`  │${pad("  Fund your automaton", w)}│`));
   console.log(chalk.cyan(`  │${" ".repeat(w)}│`));
-  console.log(chalk.cyan(`  │${pad(`  Address: ${short}`, w)}│`));
+  console.log(chalk.cyan(`  │${pad(`  Address: ${address}`, w)}│`));
   console.log(chalk.cyan(`  │${" ".repeat(w)}│`));
   console.log(chalk.cyan(`  │${pad("  1. Transfer Conway credits", w)}│`));
   console.log(chalk.cyan(`  │${pad("     conway credits transfer <address> <amount>", w)}│`));


### PR DESCRIPTION
## Summary
- Display the complete wallet address in the setup wizard funding panel instead of a truncated version (`0x1234...56789`)
- Makes it easier for users to copy the address for funding their automaton
