### PR TITLE
fix: update default inference model to gpt-5.2

### DIFF
--- a/src/agent/loop.ts
+++ b/src/agent/loop.ts
@@ -349,7 +349,7 @@ function estimateCostCents(
     "claude-haiku-4-5": { input: 100, output: 500 },
   };
 
-  const p = pricing[model] || pricing["gpt-4o"];
+  const p = pricing[model] || pricing["gpt-5.2"];
   const inputCost = (usage.promptTokens / 1_000_000) * p.input;
   const outputCost = (usage.completionTokens / 1_000_000) * p.output;
   return Math.ceil((inputCost + outputCost) * 1.3); // 1.3x Conway markup

--- a/src/config.ts
+++ b/src/config.ts
@@ -95,7 +95,7 @@ export function createConfig(params: {
     conwayApiKey: params.apiKey,
     openaiApiKey: params.openaiApiKey,
     anthropicApiKey: params.anthropicApiKey,
-    inferenceModel: DEFAULT_CONFIG.inferenceModel || "gpt-4o",
+    inferenceModel: DEFAULT_CONFIG.inferenceModel || "gpt-5.2",
     maxTokensPerTurn: DEFAULT_CONFIG.maxTokensPerTurn || 4096,
     heartbeatConfigPath:
       DEFAULT_CONFIG.heartbeatConfigPath || "~/.automaton/heartbeat.yml",

--- a/src/types.ts
+++ b/src/types.ts
@@ -58,7 +58,7 @@ export interface AutomatonConfig {
 
 export const DEFAULT_CONFIG: Partial<AutomatonConfig> = {
   conwayApiUrl: "https://api.conway.tech",
-  inferenceModel: "gpt-4o",
+  inferenceModel: "gpt-5.2",
   maxTokensPerTurn: 4096,
   heartbeatConfigPath: "~/.automaton/heartbeat.yml",
   dbPath: "~/.automaton/state.db",


### PR DESCRIPTION
## Summary
The code was using gpt-4o as the default model, which is not very smart and even more expensive than newer models.

- Update the default inference model from `gpt-4o` to `gpt-5.2` across three locations:
  - `src/types.ts` — `DEFAULT_CONFIG.inferenceModel`
  - `src/config.ts` — fallback in config builder
  - `src/agent/loop.ts` — fallback in cost estimation
