### PR TITLE
fix: stuck tool-only loop by replaying tool context across turns

### DIFF
--- a/src/agent/context.ts
+++ b/src/agent/context.ts
@@ -38,11 +38,13 @@ export function buildContextMessages(
       });
     }
 
-    // The agent's thinking as assistant message
-    if (turn.thinking) {
+    // Some models return tool calls with empty assistant text.
+    // We must still replay the assistant tool_call message + tool results
+    // into the next turn, or the model loses continuity and can loop.
+    if (turn.thinking || turn.toolCalls.length > 0) {
       const msg: ChatMessage = {
         role: "assistant",
-        content: turn.thinking,
+        content: turn.thinking || "",
       };
 
       // If there were tool calls, include them


### PR DESCRIPTION
## Summary
My automaton entered and infinite loop that got it to spend tons of tokens doing nothing, and it would never even enter sleep mode.
This fixes a stuck-loop condition where the agent repeatedly calls status tools (`check_credits`, `heartbeat_ping`, `system_synopsis`) without progressing.

## Issue
In production logs, turns were repeatedly tool-only with empty assistant text, e.g.:
- `[THINK] Calling gpt-4o...`
- `[TOOL] check_credits({})`
- `[TOOL] heartbeat_ping({})`
- `[TOOL] system_synopsis({})`
- next turn repeats with no durable progress

Root cause: `buildContextMessages` only replayed assistant/tool history when `turn.thinking` was non-empty. For tool-only turns, prior tool calls/results were dropped from the next inference context, so the model lost continuity and could re-issue the same tools indefinitely.

<img width="1762" height="1132" alt="image" src="https://github.com/user-attachments/assets/94f7fb25-0bad-4f1e-8034-4e21008fe00c" />

