### PR TITLE
fix(agent): set sleeping state on sleep_until early exit

### DIFF
--- a/src/agent/loop.ts
+++ b/src/agent/loop.ts
@@ -111,6 +111,8 @@ export async function runAgentLoop(
       const sleepUntil = db.getKV("sleep_until");
       if (sleepUntil && new Date(sleepUntil) > new Date()) {
         log(config, `[SLEEP] Sleeping until ${sleepUntil}`);
+        db.setAgentState("sleeping");
+        onStateChange?.("sleeping");
         running = false;
         break;
       }

--- a/src/index.ts
+++ b/src/index.ts
@@ -335,6 +335,13 @@ async function run(): Promise<void> {
         // Clear sleep state
         db.deleteKV("sleep_until");
         continue;
+      } else {
+        // Unexpected state after loop exit — guard against tight loop
+        console.log(
+          `[${new Date().toISOString()}] Unexpected state "${state}" after loop exit. Waiting 5s.`,
+        );
+        await sleep(5_000);
+        continue;
       }
     } catch (err: any) {
       console.error(


### PR DESCRIPTION
## Summary

- Fix tight wake loop caused by missing state transition on `sleep_until` early exit
- Add defensive fallback in outer loop for unexpected states

## Bug

When `runAgentLoop` exits via the `sleep_until` early-exit path (line ~113 in `loop.ts`), agent state was left as `"running"`. The outer loop in `index.ts` only enters the sleep/wait branch when state is `"sleeping"`, so the agent immediately re-entered the loop — burning ~6-8K tokens per cycle with no useful work.

Observed: ~10 re-entries in 20 seconds before the fix.

## Root Cause

The `sleep_until` early-exit branch in `runAgentLoop` breaks out of the loop and sets `running = false`, but never calls `db.setAgentState("sleeping")` or fires `onStateChange`. The outer loop in `index.ts` checks `state === "sleeping"` to decide whether to wait — with state still `"running"`, it falls through and re-enters immediately.

## Fix

**`src/agent/loop.ts` (line 113-114):** Add `db.setAgentState("sleeping")` and `onStateChange?.("sleeping")` in the `sleep_until` early-exit branch, before setting `running = false`.

**`src/index.ts` (line 338):** Add an `else` fallback after the `sleeping`/`idle` state checks that logs the unexpected state and waits 5 seconds before continuing. This guards against tight loops from any future state mismatch.

## Verification

Tested locally — agent correctly transitions to sleeping state and the outer loop waits as expected. No tight loop observed after the fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)