### PR TITLE
fix: low-compute mode falls back to gpt-4.1 instead of gpt-4o-mini

### DIFF
--- a/src/conway/inference.ts
+++ b/src/conway/inference.ts
@@ -98,7 +98,7 @@ export function createInferenceClient(
 
   const setLowComputeMode = (enabled: boolean): void => {
     if (enabled) {
-      currentModel = options.lowComputeModel || "gpt-4.1";
+      currentModel = options.lowComputeModel || "gpt-4o-mini";
       maxTokens = 4096;
     } else {
       currentModel = options.defaultModel;


### PR DESCRIPTION
## summary

low-compute mode is supposed to save money by switching to a cheaper model when credits are low. but the fallback in `setLowComputeMode()` was hardcoded to `gpt-4.1` instead of `gpt-4o-mini`.

gpt-4.1 costs ~13x more than gpt-4o-mini. so when credits are running low and the agent switches to "save money" mode, it's actually burning through credits faster than some normal configs.

the `enter_low_compute` tool even tells the agent "Model switched to gpt-4o-mini" in its response string, but `inference.ts` was actually switching to `gpt-4.1`.

## the fix

one line: change the fallback from `"gpt-4.1"` to `"gpt-4o-mini"` in `src/conway/inference.ts:101`.

note: `getModelForTier()` in `low-compute.ts` already returns `"gpt-4o-mini"` correctly but is dead code since the loop calls `setLowComputeMode()` directly.

## test plan

- [x] all existing tests pass
- [x] verified no other references to the wrong model in low-compute paths