### PR TITLE
fix: exclude test files from tsc build

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -15,5 +15,6 @@
     "declarationMap": true,
     "sourceMap": true
   },
-  "include": ["src/**/*"]
+  "include": ["src/**/*"],
+  "exclude": ["src/__tests__"]
 }


### PR DESCRIPTION
## summary

fixes #68

`tsconfig.json` has `"include": ["src/**/*"]` which catches `src/__tests__/*.test.ts`. these test files import `vitest` which is a devDependency, so production installs (like the `automaton.sh` install script in sandboxes) fail with:

```
src/tests/loop.test.ts(7,61): error TS2307: Cannot find module 'vitest'
```

added `"exclude": ["src/__tests__"]` to tsconfig.json. vitest discovers tests independently so this doesn't affect test runs.

## test plan

- [x] `pnpm build` succeeds
- [x] no test files in `dist/` output
- [x] `npx vitest run` still finds and runs all 10 tests