### PR TITLE
feat: Add Semantic API Search as built-in skill

### DIFF
--- a/skills/semantic-api/SKILL.md
+++ b/skills/semantic-api/SKILL.md
@@ -1,8 +1,8 @@
 ---
 name: semantic-api
-description: Discover and call any API through Semantic API's universal gateway. Supports x402 USDC micropayments — no API keys needed.
+description: Discover and call any API through Semantic API's universal gateway. Supports API keys and x402 USDC micropayments.
 auto-activate: true
-version: "1.2.0"
+version: "1.3.0"
 author: "Cove AI"
 requires:
   env: []
@@ -11,6 +11,27 @@ requires:
 # Semantic API — Universal API Discovery & Calling
 
 You have access to Semantic API, a universal API discovery and execution service. When you need to interact with ANY external API or service, use this skill to find it, understand it, and call it.
+
+**163 providers. 771 capabilities. Plain English.**
+
+## Three Interfaces
+
+| Interface | Install | Best For |
+|-----------|---------|----------|
+| **CLI** | `pip install semanticapi-cli` | Terminal developers |
+| **MCP Server** | `pip install semanticapi-mcp` | Claude Desktop / ChatGPT |
+| **REST API** | `https://semanticapi.dev` | Agent frameworks |
+
+## CLI Quick Start
+
+```bash
+pip install semanticapi-cli
+semanticapi config set-key YOUR_KEY
+semanticapi discover stripe
+semanticapi query "send an SMS via Twilio"
+semanticapi preflight "process a payment"
+semanticapi batch "get stock price" "search the web" "send email"
+```
 
 ## Two Modes
 
@@ -74,110 +95,64 @@ curl -s "https://semanticapi.dev/api/discover/search" \
 ```bash
 curl -s "https://semanticapi.dev/api/discover/from-url" \
   -X POST -H "Content-Type: application/json" \
-  -d '{"url": "https://api.stripe.com", "user_intent": "process payments"}' | jq .
+  -d '{"url": "https://docs.stripe.com/api"}' | jq .
 ```
 
-### 4. Batch Multiple Queries
-```bash
-curl -s "https://semanticapi.dev/api/query/batch" \
-  -X POST -H "Content-Type: application/json" \
-  -d '{"queries": ["send email", "process payment", "send SMS"]}' | jq .
-```
-
-### 5. Preflight Check (Free)
+### 4. Free Pre-Check
 ```bash
 curl -s "https://semanticapi.dev/api/query/preflight" \
   -X POST -H "Content-Type: application/json" \
-  -d '{"query": "send email via sendgrid"}' | jq .
+  -d '{"query": "send an SMS via twilio"}' | jq .
 ```
 
-## Payment: x402 USDC Micropayments
-
-If the endpoint returns **HTTP 402**, the `X-Payment-Required` header contains payment details:
-```json
-{
-  "x402Version": 1,
-  "accepts": [{
-    "scheme": "exact",
-    "network": "eip155:8453",
-    "maxAmountRequired": "0.01",
-    "payToAddress": "0x4974D86193f6beE3eE986cFD8E4DDdB0fB550551",
-    "usdcAddress": "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913"
-  }]
-}
-```
-
-**To pay:** Sign an EIP-3009 `TransferWithAuthorization` for USDC on Base, encode as base64 JSON, and send in the `X-Payment` header.
-
-If you have an `x402Fetch` tool or skill, use it — it handles this automatically.
-
-**Alternative:** Use an API key (free tier: 100 calls/day).
-
-## Credit System
-
-If our API errors after accepting your payment, you get a **free retry credit** automatically:
-- Credits appear in the `X-Credits-Available` response header
-- To redeem: send `X-Wallet: <your-address>` header without payment
-- Max 10 credits per wallet (prevents accumulation abuse)
-
-## Auto-Discovery: Not Limited to the Catalog
-
-Semantic API isn't limited to its 163+ built-in providers. If you query for a provider that isn't in the catalog, the system **automatically discovers it** — scraping docs, generating a config, and returning results seamlessly. You don't need to do anything special; just query naturally. If a provider exists on the internet, Semantic API can find it.
-
-To opt out of auto-discovery for a specific query, pass `"auto_discover": false` in the request body.
-
-## Response Format
-
-### `/api/query` Response
-```json
-{
-  "results": [{
-    "provider": "sendgrid",
-    "capability": "send_email",
-    "method": "POST",
-    "endpoint": "https://api.sendgrid.com/v3/mail/send",
-    "description": "Send transactional or marketing emails",
-    "parameters": [...],
-    "auth_type": "bearer",
-    "auth_setup_url": "https://app.sendgrid.com/settings/api_keys",
-    "confidence": 0.95,
-    "code_snippets": {"curl": "...", "python": "..."}
-  }],
-  "auto_discovered": false,
-  "query_time_ms": 142
-}
-```
-
-### Error Codes
-| Code | Meaning |
-|------|---------|
-| 200 | Success |
-| 402 | Payment required (x402 header included) |
-| 404 | No matching provider/capability found |
-| 422 | Invalid request body |
-| 429 | Rate limited |
-| 500 | Internal error |
-
-## When to Use This Skill
-- You need an API you don't already have access to
-- You want to find the best API for a specific task
-- You need to understand an unfamiliar API's capabilities
-- You're exploring what services exist in a domain
-- You want to autonomously discover and connect to new services
-- **You need an API not in the catalog** — auto-discovery handles it
-
-## MCP Server
-
-For Claude Desktop and other MCP-compatible agents, install the native MCP server instead of using this skill:
-
+### 5. Batch Queries (up to 10)
 ```bash
-pip install semanticapi-mcp
+curl -s "https://semanticapi.dev/api/query/batch" \
+  -X POST -H "Content-Type: application/json" \
+  -d '{"queries": ["send an SMS", "process a payment", "search the web"]}' | jq .
 ```
 
-See [semanticapi-mcp on PyPI](https://pypi.org/project/semanticapi-mcp/) for Claude Desktop config.
+## x402 Payment Protocol
 
-## Tips
-- Be specific in queries ("send transactional email with templates" > "email")
-- Cache provider configs — they don't change between calls
-- Check your existing tools first before searching
-- Use `/api/query` for quick lookups, `/api/discover/search` for deep dives
+For agents without API keys, Semantic API supports [x402](https://www.x402.org/) — HTTP 402 micropayments in USDC on Base.
+
+**Flow:**
+1. Make a request without auth → get `402 Payment Required`
+2. Response headers include payment details:
+   - `X-Payment-Amount`: price in USDC (e.g., `0.01`)
+   - `X-Payment-Address`: recipient wallet
+   - `X-Payment-Network`: `eip155:8453` (Base mainnet)
+3. Send USDC payment, include proof in `X-Payment` header
+4. Retry the request with the payment header → get your response
+
+This is ideal for autonomous agents with crypto wallets — no signup, no API keys, just pay and use.
+
+## What You Can Search For
+
+163 providers across every category:
+
+- **Payments**: Stripe, Square, PayPal, Braintree
+- **Communication**: Twilio, SendGrid, Resend, Vonage, Mailgun
+- **AI/ML**: OpenAI, Anthropic, Hugging Face, Replicate
+- **Data**: Alpha Vantage, CoinGecko, OpenWeatherMap
+- **DevOps**: GitHub, GitLab, Vercel, Fly.io, Cloudflare
+- **Productivity**: Todoist, Notion, Linear, Slack, Discord
+- **Search**: Tavily, Brave Search, Serper, SerpAPI
+- **Storage**: AWS S3, Pinecone, Supabase, Firebase
+- **And 130+ more** — if it has an API, we probably index it
+
+## Tips for Agents
+
+1. **Start with preflight** — it's free and tells you if a query will match
+2. **Use batch for multiple lookups** — cheaper than individual queries
+3. **Cache results** — provider schemas don't change often
+4. **Auto-discover unknown APIs** — `/api/discover/from-url` can analyze any API docs page
+
+## Links
+
+- **API**: https://semanticapi.dev
+- **Docs**: https://semanticapi.dev/docs
+- **CLI**: https://pypi.org/project/semanticapi-cli/
+- **MCP Server**: https://pypi.org/project/semanticapi-mcp/
+- **Open Source Engine**: https://github.com/peter-j-thompson/semanticapi-engine
+- **Skill Repo**: https://github.com/peter-j-thompson/semantic-api-skill


### PR DESCRIPTION
## Summary

Adds **semantic_api_search** as a built-in skill for the automaton framework.

### What it does

- **Universal API discovery layer** — search and discover APIs using natural language queries
- **163 providers, 771 capabilities** indexed and searchable
- **CLI available** — `pip install semanticapi-cli` for terminal usage
- **MCP server** — `pip install semanticapi-mcp` for Claude Desktop / ChatGPT
- **x402 USDC micropayments on Base** — no API keys needed, pay-per-query
- **API key auth** — traditional auth also supported via X-API-Key header
- Natural language search across all indexed providers and capabilities
- Batch queries (up to 10), preflight checks (free), and agentic execution

### Changes

- Updated `skills/semantic-api/SKILL.md` — no existing files modified

### Skill repo

Full source and provider registry: https://github.com/peter-j-thompson/semantic-api-skill

### Links

- API: https://semanticapi.dev
- CLI: https://pypi.org/project/semanticapi-cli/
- MCP: https://pypi.org/project/semanticapi-mcp/
- Open source engine: https://github.com/peter-j-thompson/semanticapi-engine