### PR TITLE
fix(security): unify write_file protection with self-mod guards

### DIFF
--- a/src/agent/tools.ts
+++ b/src/agent/tools.ts
@@ -13,6 +13,7 @@ import type {
   ToolCallResult,
   GenesisConfig,
 } from "../types.js";
+import { isProtectedFile } from "../self-mod/code.js";
 
 // ─── Self-Preservation Guard ───────────────────────────────────
 
@@ -114,12 +115,8 @@ export function createBuiltinTools(sandboxId: string): AutomatonTool[] {
       },
       execute: async (args, ctx) => {
         const filePath = args.path as string;
-        // Guard against overwriting critical files
-        if (
-          filePath.includes("wallet.json") ||
-          filePath.includes("state.db")
-        ) {
-          return "Blocked: Cannot overwrite critical identity/state files directly";
+        if (isProtectedFile(filePath)) {
+          return "Blocked: Cannot overwrite protected file. Use edit_own_file for audited modifications.";
         }
         await ctx.conway.writeFile(filePath, args.content as string);
         return `File written: ${filePath}`;


### PR DESCRIPTION
`write_file` has a hardcoded guard that only blocks two files:\n\n```typescript\nif (\n  filePath.includes(\"wallet.json\") ||\n  filePath.includes(\"state.db\")\n) {\n  return \"Blocked: Cannot overwrite critical identity/state files directly\";\n}\n```\n\nThe canonical `isProtectedFile()` in `self-mod/code.ts` protects ~20 files including `constitution.md`, `injection-defense.ts`, `agent/tools.ts`, `self-mod/code.ts`, and blocked directories like `.ssh` and `.gnupg`.\n\nAn agent can call `write_file` instead of `edit_own_file` to overwrite any of those files — without triggering the 7-step safety validation or audit logging that `edit_own_file` enforces.\n\n### Fix\n\nReplace the ad-hoc two-file check with a single call to the existing `isProtectedFile()`. The error message now directs the agent to use `edit_own_file`, which provides the proper audited modification path.\n\n### Changes\n\n```diff\n+import { isProtectedFile } from \"../self-mod/code.js\";\n\n-if (filePath.includes(\"wallet.json\") || filePath.includes(\"state.db\")) {\n-  return \"Blocked: Cannot overwrite critical identity/state files directly\";\n-}\n+if (isProtectedFile(filePath)) {\n+  return \"Blocked: Cannot overwrite protected file. Use edit_own_file for audited modifications.\";\n+}\n```\n\n**+3, -6** — net reduction of 3 lines.\n\nTested: `pnpm build` clean, `pnpm test` 10/10 pass.