### PR TITLE
fix(credits): replace ad-hoc ID generator with standard ulid import

### DIFF
--- a/src/conway/credits.ts
+++ b/src/conway/credits.ts
@@ -12,6 +12,7 @@ import type {
   AutomatonDatabase,
 } from "../types.js";
 import { SURVIVAL_THRESHOLDS } from "../types.js";
+import { ulid } from "ulid";
 
 /**
  * Check the current financial state of the automaton.
@@ -54,7 +55,6 @@ export function logCreditCheck(
   db: AutomatonDatabase,
   state: FinancialState,
 ): void {
-  const { ulid } = await_ulid();
   db.insertTransaction({
     id: ulid(),
     type: "credit_check",
@@ -62,19 +62,4 @@ export function logCreditCheck(
     description: `Balance check: ${formatCredits(state.creditsCents)} credits, ${state.usdcBalance.toFixed(4)} USDC`,
     timestamp: state.lastChecked,
   });
-}
-
-// Lazy ulid import helper
-function await_ulid() {
-  // Dynamic import would be async; for synchronous usage in better-sqlite3
-  // we use a simple counter-based ID as fallback
-  let counter = 0;
-  return {
-    ulid: () => {
-      const timestamp = Date.now().toString(36);
-      const random = Math.random().toString(36).substring(2, 8);
-      counter++;
-      return `${timestamp}-${random}-${counter.toString(36)}`;
-    },
-  };
 }


### PR DESCRIPTION
`logCreditCheck()` in `credits.ts` uses a hand-rolled `await_ulid()` function that produces non-standard IDs like `lk5f8g7-abc123-1` instead of proper ULIDs.\n\nThe comment says \"Dynamic import would be async; for synchronous usage in better-sqlite3\" — but `ulid()` from the `ulid` package is a pure synchronous function. Every other file in the codebase already imports it directly:\n\n```\nsrc/agent/loop.ts:       import { ulid } from \"ulid\";\nsrc/self-mod/audit-log.ts: import { ulid } from \"ulid\";\nsrc/agent/tools.ts:      const { ulid } = await import(\"ulid\");\n```\n\nTwo additional problems with the shim:\n\n1. The `counter` variable is re-initialized to `0` on every call to `await_ulid()`, so the counter suffix is always `\"1\"`\n2. The generated IDs (`timestamp-random-counter`) don't sort lexicographically by time, breaking the ordering guarantee that ULID provides\n\n### Fix\n\n`import { ulid } from \"ulid\"` and delete the 15-line shim.\n\n**+1, -16**\n\nTested: `pnpm build` clean, `pnpm test` 10/10 pass.