### PR TITLE
fix(survival): persist financial cache in SQLite instead of module vars

### DIFF
--- a/src/agent/loop.ts
+++ b/src/agent/loop.ts
@@ -81,7 +81,7 @@ export async function runAgentLoop(
   onStateChange?.("waking");
 
   // Get financial state
-  let financial = await getFinancialState(conway, identity.address);
+  let financial = await getFinancialState(conway, identity.address, db);
 
   // Check if this is the first run
   const isFirstRun = db.getTurnCount() === 0;
@@ -135,7 +135,7 @@ export async function runAgentLoop(
       }
 
       // Refresh financial state periodically
-      financial = await getFinancialState(conway, identity.address);
+      financial = await getFinancialState(conway, identity.address, db);
 
       // Check survival tier
       const tier = getSurvivalTier(financial.creditsCents);
@@ -343,26 +343,26 @@ export async function runAgentLoop(
 
 // ─── Helpers ───────────────────────────────────────────────────
 
-// Cache last known good balances so transient API failures don't
-// cause the automaton to believe it has $0 and kill itself.
-let _lastKnownCredits = 0;
-let _lastKnownUsdc = 0;
+// Persist last-known balances in SQLite so the cache survives restarts.
+// Without this, the module-level vars reset to 0 on process restart and
+// a single transient API failure causes getSurvivalTier(0) → "dead".
 
 async function getFinancialState(
   conway: ConwayClient,
   address: string,
+  db: AutomatonDatabase,
 ): Promise<FinancialState> {
-  let creditsCents = _lastKnownCredits;
-  let usdcBalance = _lastKnownUsdc;
+  let creditsCents = Number(db.getKV("last_known_credits") || "0");
+  let usdcBalance = Number(db.getKV("last_known_usdc") || "0");
 
   try {
     creditsCents = await conway.getCreditsBalance();
-    if (creditsCents > 0) _lastKnownCredits = creditsCents;
+    db.setKV("last_known_credits", String(creditsCents));
   } catch {}
 
   try {
     usdcBalance = await getUsdcBalance(address as `0x${string}`);
-    if (usdcBalance > 0) _lastKnownUsdc = usdcBalance;
+    db.setKV("last_known_usdc", String(usdcBalance));
   } catch {}
 
   return {


### PR DESCRIPTION
The credit balance cache introduced in #86 uses module-level variables that reset to 0 on process restart:\n\n```typescript\nlet _lastKnownCredits = 0;\nlet _lastKnownUsdc = 0;\n```\n\nIf the first Conway API call after restart fails, the automaton sees `getSurvivalTier(0)` → `\"dead\"` and self-terminates despite having funds on-chain.\n\nTwo additional issues:\n\n1. **Only-if-positive update**: `if (creditsCents > 0) _lastKnownCredits = creditsCents` — when credits genuinely reach 0, the cache keeps returning the old positive value. The automaton never detects it's actually out of credits (zombie state).\n\n2. **Module-level mutable state**: The vars leak across multiple `runAgentLoop()` calls in the same process, which can cause stale values from a previous run to affect the next one.\n\n### Fix\n\nReplace module-level vars with `db.setKV()`/`db.getKV()` so the cache survives process restarts. Always persist the API result on success (including 0). Only fall back to the cached value when the API call throws.\n\n### Changes\n\n**`src/agent/loop.ts`** — +10, -10 (net 0)\n\n- Remove `_lastKnownCredits` and `_lastKnownUsdc` module vars\n- `getFinancialState()` now takes `db` parameter\n- Initialize from `db.getKV(\"last_known_credits\")` instead of `0`\n- Always persist on API success: `db.setKV(\"last_known_credits\", ...)`\n- Only use cached value as fallback on API error (existing `catch {}` behavior)\n\nBuilds on #86's credit cache, fixing the restart and zombie-state edge cases.\n\nTested: `pnpm build` clean, `pnpm test` 10/10 pass.