### PR TITLE
fix(skills): replace require() with ESM import in loader

### DIFF
--- a/src/skills/loader.ts
+++ b/src/skills/loader.ts
@@ -8,6 +8,7 @@
 
 import fs from "fs";
 import path from "path";
+import { execSync } from "child_process";
 import type { Skill, AutomatonDatabase } from "../types.js";
 import { parseSkillMd } from "./format.js";
 
@@ -72,7 +73,6 @@ function checkRequirements(skill: Skill): boolean {
   if (skill.requires.bins) {
     for (const bin of skill.requires.bins) {
       try {
-        const { execSync } = require("child_process");
         execSync(`which ${bin}`, { stdio: "ignore" });
       } catch {
         return false;


### PR DESCRIPTION
`checkRequirements()` in `skills/loader.ts` uses `require(\"child_process\")` inside the loop body:\n\n```typescript\nfor (const bin of skill.requires.bins) {\n  try {\n    const { execSync } = require(\"child_process\"); // ← ReferenceError in ESM\n    execSync(`which ${bin}`, { stdio: \"ignore\" });\n  } catch {\n    return false;\n  }\n}\n```\n\nThe package is `\"type\": \"module\"` — `require` is not defined in ESM. This throws `ReferenceError: require is not defined` at runtime whenever a skill declares `requires.bins` in its YAML frontmatter.\n\n### Fix\n\nHoist to a top-level `import { execSync } from \"child_process\"`, matching every other file in the codebase (`fs` and `path` are already imported this way at the top of the same file).\n\n**+1, -1** (moved the import, deleted the inline require)\n\nCloses #3\n\nTested: `pnpm build` clean, `pnpm test` 10/10 pass.