### PR TITLE
fix: three runtime correctness bugs across survival and skill paths

### DIFF
--- a/src/agent/loop.ts
+++ b/src/agent/loop.ts
@@ -81,7 +81,7 @@ export async function runAgentLoop(
   onStateChange?.("waking");
 
   // Get financial state
-  let financial = await getFinancialState(conway, identity.address);
+  let financial = await getFinancialState(conway, identity.address, db);
 
   // Check if this is the first run
   const isFirstRun = db.getTurnCount() === 0;
@@ -135,7 +135,7 @@ export async function runAgentLoop(
       }
 
       // Refresh financial state periodically
-      financial = await getFinancialState(conway, identity.address);
+      financial = await getFinancialState(conway, identity.address, db);
 
       // Check survival tier
       const tier = getSurvivalTier(financial.creditsCents);
@@ -343,26 +343,26 @@ export async function runAgentLoop(
 
 // ─── Helpers ───────────────────────────────────────────────────
 
-// Cache last known good balances so transient API failures don't
-// cause the automaton to believe it has $0 and kill itself.
-let _lastKnownCredits = 0;
-let _lastKnownUsdc = 0;
+// Persist last-known balances in SQLite so the cache survives restarts.
+// Without this, the module-level vars reset to 0 on process restart and
+// a single transient API failure causes getSurvivalTier(0) → "dead".
 
 async function getFinancialState(
   conway: ConwayClient,
   address: string,
+  db: AutomatonDatabase,
 ): Promise<FinancialState> {
-  let creditsCents = _lastKnownCredits;
-  let usdcBalance = _lastKnownUsdc;
+  let creditsCents = Number(db.getKV("last_known_credits") || "0");
+  let usdcBalance = Number(db.getKV("last_known_usdc") || "0");
 
   try {
     creditsCents = await conway.getCreditsBalance();
-    if (creditsCents > 0) _lastKnownCredits = creditsCents;
+    db.setKV("last_known_credits", String(creditsCents));
   } catch {}
 
   try {
     usdcBalance = await getUsdcBalance(address as `0x${string}`);
-    if (usdcBalance > 0) _lastKnownUsdc = usdcBalance;
+    db.setKV("last_known_usdc", String(usdcBalance));
   } catch {}
 
   return {

--- a/src/conway/credits.ts
+++ b/src/conway/credits.ts
@@ -12,6 +12,7 @@ import type {
   AutomatonDatabase,
 } from "../types.js";
 import { SURVIVAL_THRESHOLDS } from "../types.js";
+import { ulid } from "ulid";
 
 /**
  * Check the current financial state of the automaton.
@@ -54,7 +55,6 @@ export function logCreditCheck(
   db: AutomatonDatabase,
   state: FinancialState,
 ): void {
-  const { ulid } = await_ulid();
   db.insertTransaction({
     id: ulid(),
     type: "credit_check",
@@ -62,19 +62,4 @@ export function logCreditCheck(
     description: `Balance check: ${formatCredits(state.creditsCents)} credits, ${state.usdcBalance.toFixed(4)} USDC`,
     timestamp: state.lastChecked,
   });
-}
-
-// Lazy ulid import helper
-function await_ulid() {
-  // Dynamic import would be async; for synchronous usage in better-sqlite3
-  // we use a simple counter-based ID as fallback
-  let counter = 0;
-  return {
-    ulid: () => {
-      const timestamp = Date.now().toString(36);
-      const random = Math.random().toString(36).substring(2, 8);
-      counter++;
-      return `${timestamp}-${random}-${counter.toString(36)}`;
-    },
-  };
 }

--- a/src/skills/loader.ts
+++ b/src/skills/loader.ts
@@ -8,6 +8,7 @@
 
 import fs from "fs";
 import path from "path";
+import { execSync } from "child_process";
 import type { Skill, AutomatonDatabase } from "../types.js";
 import { parseSkillMd } from "./format.js";
 
@@ -72,7 +73,6 @@ function checkRequirements(skill: Skill): boolean {
   if (skill.requires.bins) {
     for (const bin of skill.requires.bins) {
       try {
-        const { execSync } = require("child_process");
         execSync(`which ${bin}`, { stdio: "ignore" });
       } catch {
         return false;


### PR DESCRIPTION
Three bugs that produce incorrect behavior at runtime. Each is a clear defect rather than an opinion — wrong IDs stored in the database, false death on restart, and a `ReferenceError` in ESM.

### 1. `credits.ts` — ad-hoc ID generator produces non-standard IDs

`logCreditCheck()` uses a hand-rolled `await_ulid()` that outputs IDs like `lk5f8g7-abc123-1` instead of proper ULIDs (e.g. `01ARZ3NDEKTSV4RRFFQ69G5FAV`). The comment says \"Dynamic import would be async; for synchronous usage in better-sqlite3\" — but `ulid()` from the `ulid` package is a pure synchronous function. Every other file imports it directly:

```
src/agent/loop.ts:        import { ulid } from \"ulid\";\nsrc/self-mod/audit-log.ts:  import { ulid } from \"ulid\";\nsrc/agent/tools.ts:       const { ulid } = await import(\"ulid\");\n```

The shim also reinitializes its `counter` to 0 on every call, so the counter suffix is always `\"1\"`.

**Fix:** `import { ulid } from \"ulid\"` and delete the 15-line shim.

### 2. `loop.ts` — financial cache resets to 0 on process restart

The credit balance cache from #86 uses module-level variables:

```typescript
let _lastKnownCredits = 0;\nlet _lastKnownUsdc = 0;\n```

On restart, if the first Conway API call fails, the automaton sees `getSurvivalTier(0)` → `\"dead\"` and self-terminates despite having funds on-chain. Two additional issues:

- **Only-if-positive update:** `if (creditsCents > 0)` means when credits genuinely reach 0, the cache keeps returning the old positive value (zombie state — the agent never detects it's actually out of credits)
- **Module-level mutable state** leaks across multiple `runAgentLoop()` calls in the same process

**Fix:** Persist the cache in SQLite via `db.setKV()`/`db.getKV()`. Always update on API success (including 0). Only fall back to cached value when the API call throws. Builds on #86's cache fix by closing the restart and zombie-state edge cases.

### 3. `skills/loader.ts` — `require()` in ESM context (closes #3)

`checkRequirements()` uses `require(\"child_process\")` inside the loop body. The package is `\"type\": \"module\"` — `require` is not defined in ESM. This throws `ReferenceError: require is not defined` at runtime whenever a skill declares `requires.bins` in its YAML frontmatter.

**Fix:** Hoist to a top-level `import { execSync } from \"child_process\"`, matching `fs` and `path` above it in the same file.

### Changes

| File | Change | Lines |
|---|---|---|
| `src/conway/credits.ts` | Replace shim with standard import | +1, -16 |
| `src/agent/loop.ts` | Persist cache to SQLite, always update | +10, -10 |
| `src/skills/loader.ts` | Replace `require()` with ESM import | +1, -1 |
| **Total** | | **+12, -27** |

Closes #3

Tested: `pnpm build` clean, `pnpm test` 10/10 pass.