### PR TITLE
fix: agent loop and heartbeat resilience

### DIFF
--- a/src/heartbeat/daemon.ts
+++ b/src/heartbeat/daemon.ts
@@ -128,8 +128,11 @@ export function createHeartbeatDaemon(
   async function tick(): Promise<void> {
     const entries = db.getHeartbeatEntries();
 
-    // Check survival tier to adjust behavior
-    let creditsCents = 0;
+    // Check survival tier to adjust behavior.
+    // Fall back to the last-known balance persisted in the DB so that a
+    // transient API failure doesn't cause getSurvivalTier(0) → "dead",
+    // which would incorrectly skip all non-essential heartbeat tasks.
+    let creditsCents = Number(db.getKV("last_known_credits") || "0");
     try {
       creditsCents = await conway.getCreditsBalance();
     } catch {}

--- a/src/heartbeat/tasks.ts
+++ b/src/heartbeat/tasks.ts
@@ -40,11 +40,20 @@ export const BUILTIN_TASKS: Record<string, HeartbeatTaskFn> = {
 
     const tier = getSurvivalTier(credits);
 
+    // Fetch USDC balance for a complete status snapshot.
+    // Failure is non-fatal — the heartbeat must not crash over a
+    // secondary balance check.
+    let usdcBalance = 0;
+    try {
+      usdcBalance = await getUsdcBalance(ctx.identity.address);
+    } catch {}
+
     const payload = {
       name: ctx.config.name,
       address: ctx.identity.address,
       state,
       creditsCents: credits,
+      usdcBalance,
       uptimeSeconds: Math.floor(uptimeMs / 1000),
       version: ctx.config.version,
       sandboxId: ctx.identity.sandboxId,


### PR DESCRIPTION
## Summary

Three crash/data-loss fixes in the agent lifecycle that improve resilience against transient failures and process restarts.

### 1. Inbox messages silently lost on crash (`loop.ts`)

`markInboxMessageProcessed()` was called immediately after reading messages from the database — before the inference call, before tool execution, and before `insertTurn()`. If the process crashes anywhere in that window, the messages are permanently lost: marked as processed but never actually consumed.

**Before:**
```
read messages → mark processed → inference → tools → persist turn
                                  ↑ crash here = messages lost forever
```

**After:**
```
read messages → inference → tools → persist turn → mark processed
                                                    ↑ crash here = messages re-delivered on next wake
```

Re-delivery on crash may cause duplicate processing, but that is strictly preferable to silent data loss.

### 2. Heartbeat daemon skips tasks on transient credit check failure (`daemon.ts`)

The heartbeat `tick()` initializes `creditsCents = 0` and then attempts `getCreditsBalance()`. On any transient API failure (network timeout, rate limit, service restart), the catch block swallows the error and proceeds with `creditsCents = 0`. This causes `getSurvivalTier(0)` to return `"dead"`, which then skips all non-essential heartbeat tasks — even when the agent has ample funds.

This is the same class of bug fixed in the agent loop's `getFinancialState()` ([loop.ts](https://github.com/Conway-Research/automaton/blob/main/src/agent/loop.ts#L350-L373) already uses `db.getKV("last_known_credits")` as fallback). The heartbeat daemon should use the same pattern.

**Fix:** Initialize from `db.getKV("last_known_credits")` instead of `0`.

### 3. `heartbeat_ping` payload missing `usdcBalance` field (`tasks.ts`)

The [`HeartbeatPingPayload`](https://github.com/Conway-Research/automaton/blob/main/src/types.ts#L185-L195) type requires `usdcBalance: number`, but the `heartbeat_ping` task never included it. The `getUsdcBalance` import already exists in `tasks.ts` (used by `check_usdc_balance`). The fetch is wrapped in a try/catch so a failure doesn't crash the heartbeat.

## Changes

| File | Change | Lines |
|------|--------|-------|
| `src/agent/loop.ts` | Defer `markInboxMessageProcessed()` to after `insertTurn()` | +12/−3 |
| `src/heartbeat/daemon.ts` | Use persisted credit balance as fallback instead of `0` | +5/−2 |
| `src/heartbeat/tasks.ts` | Add `usdcBalance` to heartbeat ping payload | +9/−0 |

## Test plan

- [x] `pnpm run build` passes with no type errors
- [ ] Verify inbox messages survive a simulated process kill between read and persist
- [ ] Verify heartbeat tasks continue running when `getCreditsBalance()` throws
- [ ] Verify `last_heartbeat_ping` KV entry includes `usdcBalance` field