### PR TITLE
fix: prevent metrics memory leak, fix spend tracker prune and x402 limits

### DIFF
--- a/src/__tests__/observability.test.ts
+++ b/src/__tests__/observability.test.ts
@@ -282,6 +282,17 @@ describe("MetricsCollector", () => {
     it("returns empty array for unknown histogram", () => {
       expect(metrics.getHistogram("nonexistent")).toEqual([]);
     });
+
+    it("caps histogram values at 1000 to prevent memory leaks", () => {
+      for (let i = 0; i < 1500; i++) {
+        metrics.histogram("leak_test", i);
+      }
+      const values = metrics.getHistogram("leak_test");
+      expect(values.length).toBe(1000);
+      // Should keep the most recent 1000 values (500..1499)
+      expect(values[0]).toBe(500);
+      expect(values[values.length - 1]).toBe(1499);
+    });
   });
 
   describe("getAll", () => {

--- a/src/memory/ingestion.ts
+++ b/src/memory/ingestion.ts
@@ -238,7 +238,7 @@ export class MemoryIngestionPipeline {
         if (tc.name === "sleep") {
           this.working.add({
             sessionId,
-            content: `Agent chose to sleep: ${tc.result.slice(0, 200)}`,
+            content: `Agent chose to sleep: ${(tc.result || "").slice(0, 200)}`,
             contentType: "observation",
             priority: 0.3,
             sourceTurn: turn.id,
@@ -249,7 +249,7 @@ export class MemoryIngestionPipeline {
         if (tc.name === "edit_own_file" || tc.name === "update_genesis_prompt") {
           this.working.add({
             sessionId,
-            content: `Self-modification: ${tc.name} - ${tc.result.slice(0, 200)}`,
+            content: `Self-modification: ${tc.name} - ${(tc.result || "").slice(0, 200)}`,
             contentType: "decision",
             priority: 0.9,
             sourceTurn: turn.id,

--- a/src/observability/metrics.ts
+++ b/src/observability/metrics.ts
@@ -14,6 +14,9 @@ function labelKey(name: string, labels?: Record<string, string>): string {
   return `${name}{${sorted}}`;
 }
 
+// Maximum number of values to retain per histogram key
+const HISTOGRAM_MAX_VALUES = 1000;
+
 export class MetricsCollector {
   private counters = new Map<string, number>();
   private gauges = new Map<string, number>();
@@ -44,6 +47,10 @@ export class MetricsCollector {
       const key = labelKey(name, labels);
       const existing = this.histogramValues.get(key) ?? [];
       existing.push(value);
+      // Prevent unbounded memory growth by keeping only the most recent values
+      if (existing.length > HISTOGRAM_MAX_VALUES) {
+        existing.splice(0, existing.length - HISTOGRAM_MAX_VALUES);
+      }
       this.histogramValues.set(key, existing);
       this.nameStore.set(key, name);
       this.labelStore.set(key, labels ?? {});


### PR DESCRIPTION
## Summary

Four correctness fixes across observability, financial tracking, and memory ingestion:

1. **MetricsCollector histogram memory leak**: Histogram values were appended to unbounded arrays that never got pruned. Over a long-running agent lifetime, this causes linear memory growth. Added a cap of 1000 values per histogram key, retaining only the most recent entries.

2. **SpendTracker.pruneOldRecords timestamp format mismatch**: The cutoff date was formatted as ISO 8601 (`2026-02-10T14:30:00.000Z`) but SQLite's `datetime('now')` default stores as `2026-02-10 14:30:00` (no T, no Z). String comparison between these formats meant records were never actually pruned, causing slow queries over time. Fixed to match SQLite format, consistent with `getTotalSpend()` which already does this correctly.

3. **SpendTracker x402 limit reuse**: The x402 spend category incorrectly reused `maxHourlyTransferCents`/`maxDailyTransferCents` from transfer limits instead of having its own envelope. This meant x402 micropayments shared the same budget as large credit transfers. Fixed to derive x402-specific limits from `maxX402PaymentCents`.

4. **MemoryIngestionPipeline crash on undefined result**: `tc.result.slice()` was called without null check — a tool can succeed with undefined result, causing a runtime TypeError that would crash the ingestion pipeline. Fixed with `(tc.result || "").slice()`.

## Changes

- `src/observability/metrics.ts`: Add `HISTOGRAM_MAX_VALUES` cap
- `src/agent/spend-tracker.ts`: Fix prune timestamp format + x402 limits
- `src/memory/ingestion.ts`: Guard against undefined `tc.result`
- `src/__tests__/observability.test.ts`: Add histogram cap test
- `src/__tests__/spend-tracker.test.ts`: Add prune format + x402 limit tests

## Test plan

- [x] New test: histogram values capped at 1000 entries
- [x] New test: prune works with SQLite datetime format
- [x] New test: x402 limits are independent from transfer limits
- [x] All 900 existing tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)