### PR TITLE
fix: blocked inbox messages leak content into prompt, scheduler retry is dead code

### DIFF
--- a/src/agent/loop.ts
+++ b/src/agent/loop.ts
@@ -179,7 +179,7 @@ export async function runAgentLoop(
               const from = sanitizeInput(m.fromAddress, m.fromAddress, "social_address");
               const content = sanitizeInput(m.content, m.fromAddress, "social_message");
               if (content.blocked) {
-                return `[Message from ${from.content}]: ${content.content}`;
+                return `[INJECTION BLOCKED from ${from.content}]: message was blocked by safety filter`;
               }
               return `[Message from ${from.content}]: ${content.content}`;
             })

--- a/src/heartbeat/scheduler.ts
+++ b/src/heartbeat/scheduler.ts
@@ -132,6 +132,11 @@ export class DurableScheduler {
         }
       }
 
+      // Check if a retry was explicitly scheduled via nextRunAt
+      if (row.nextRunAt && new Date(row.nextRunAt) <= now) {
+        return true;
+      }
+
       // Check if task is due based on cron expression
       if (row.cronExpression) {
         try {
@@ -249,6 +254,7 @@ export class DurableScheduler {
 
     updateHeartbeatSchedule(this.db, taskName, {
       lastRunAt: now,
+      nextRunAt: null, // Clear any pending retry
       lastResult: "success",
       lastError: null,
       runCount: (this.getRunCount(taskName) ?? 0) + 1,


### PR DESCRIPTION
## Summary

Two correctness bugs in the agent loop and heartbeat scheduler:

### Bug 1: Blocked inbox messages still injected into prompt

In `loop.ts:181-184`, both the `if (content.blocked)` and `else` branches produced the **identical output string**:

```typescript
if (content.blocked) {
  return `[Message from ${from.content}]: ${content.content}`;
}
return `[Message from ${from.content}]: ${content.content}`;
```

When `sanitizeInput()` detects an injection attack and returns `{ blocked: true, content: "[BLOCKED: ...]" }`, the blocked content — including the attacker's payload text — was formatted identically to legitimate messages and injected into the agent's prompt. This defeats the purpose of injection defense.

**Fix:** Replace blocked message content with a safe, generic placeholder that does not include any attacker-controlled text.

### Bug 2: Scheduler retry mechanism is dead code

`scheduleRetry()` writes `nextRunAt` to the database, but `getDueTasks()` only evaluates `cronExpression` and `intervalMs` — it **never reads `nextRunAt`**. Failed tasks that should retry in 30 seconds instead wait for their next scheduled interval (potentially hours).

**Fix:** Add `nextRunAt` check at the top of the due-task filter, and clear `nextRunAt` on successful execution.

## Changes

- `src/agent/loop.ts`: Replace blocked message content with safe placeholder
- `src/heartbeat/scheduler.ts`: Wire `nextRunAt` into `getDueTasks()`, clear on success

## Test plan

- [x] `pnpm run typecheck` passes
- [x] All 900 tests pass (57 in affected test files)
- [x] `inbox messages cause pendingInput injection` test continues to pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)