### PR TITLE
fix: path traversal check bypassed by absolute paths without ".."

### DIFF
--- a/src/__tests__/path-protection.test.ts
+++ b/src/__tests__/path-protection.test.ts
@@ -254,6 +254,26 @@ describe("path protection policy rules", () => {
       const result = traversalRule.evaluate(request);
       expect(result).toBeNull();
     });
+
+    it("denies absolute paths outside cwd (no .. needed)", () => {
+      const request = makeMockRequest("read_file", {
+        path: "/etc/passwd",
+      });
+      request.tool = makeMockTool("read_file");
+      const result = traversalRule.evaluate(request);
+      expect(result).not.toBeNull();
+      expect(result!.action).toBe("deny");
+      expect(result!.reasonCode).toBe("PATH_TRAVERSAL");
+    });
+
+    it("denies absolute path to /tmp without traversal", () => {
+      const request = makeMockRequest("write_file", {
+        path: "/tmp/evil-script.sh",
+      });
+      const result = traversalRule.evaluate(request);
+      expect(result).not.toBeNull();
+      expect(result!.action).toBe("deny");
+    });
   });
 });
 

--- a/src/agent/policy-rules/path-protection.ts
+++ b/src/agent/policy-rules/path-protection.ts
@@ -136,18 +136,16 @@ function createTraversalDetectionRule(): PolicyRule {
       // Resolve the path first
       const resolved = path.resolve(filePath);
 
-      // After resolution, the path should not escape the working directory
-      // Check if the original path contained traversal patterns
-      if (filePath.includes("..")) {
-        // Verify the resolved path stays within the current working directory
-        const cwd = process.cwd();
-        if (!resolved.startsWith(cwd + path.sep) && resolved !== cwd) {
-          return deny(
-            "path.traversal_detection",
-            "PATH_TRAVERSAL",
-            `Path traversal detected: "${filePath}" resolves outside working directory`,
-          );
-        }
+      // Always verify the resolved path stays within the working directory,
+      // regardless of whether ".." is present — absolute paths like
+      // "/etc/passwd" can escape without using traversal sequences.
+      const cwd = process.cwd();
+      if (!resolved.startsWith(cwd + path.sep) && resolved !== cwd) {
+        return deny(
+          "path.traversal_detection",
+          "PATH_TRAVERSAL",
+          `Path resolves outside working directory: "${filePath}"`,
+        );
       }
 
       // Also check for double-slash tricks


### PR DESCRIPTION
## Summary

The `path.traversal_detection` policy rule only verified that the resolved path stayed within the working directory when the **original path contained `..`**. An attacker could use absolute paths like `/etc/passwd` to read or write files outside the working directory without triggering the traversal check:

```typescript
// Before: only checked when ".." was present
if (filePath.includes("..")) {
  const cwd = process.cwd();
  if (!resolved.startsWith(cwd + path.sep) && resolved !== cwd) {
    return deny(...);  // ← never reached for "/etc/passwd"
  }
}
```

**Fix:** Always check that the resolved path is within the working directory, regardless of whether `..` is present in the original path string.

```
Before: /etc/passwd → no ".." → check skipped → ALLOWED
After:  /etc/passwd → resolves outside cwd → DENIED
```

## Changes

- `src/agent/policy-rules/path-protection.ts`: Always verify resolved path is within cwd
- `src/__tests__/path-protection.test.ts`: Add tests for absolute path bypass

## Test plan

- [x] New test: absolute path `/etc/passwd` is denied
- [x] New test: absolute path `/tmp/evil-script.sh` is denied
- [x] Existing test: absolute path within cwd is still allowed
- [x] All 26 path protection tests pass
- [x] All 900 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)