### PR TITLE
fix: YAML parser stores requires list at wrong key + sanitization only strips first match

### DIFF
--- a/src/skills/format.ts
+++ b/src/skills/format.ts
@@ -81,9 +81,17 @@ function parseYamlFrontmatter(raw: string): SkillFrontmatter | null {
       // Check for list items
       if (trimmedLine.startsWith("- ") && inList) {
         const value = trimmedLine.slice(2).trim().replace(/^["']|["']$/g, "");
-        if (!result[listKey]) result[listKey] = [];
-        if (Array.isArray(result[listKey])) {
-          result[listKey].push(value);
+        // listKey is "requires.bins" or "requires.env" — push to the nested object
+        if (listKey.startsWith("requires.")) {
+          const nestedKey = listKey.slice("requires.".length);
+          if (result.requires && Array.isArray(result.requires[nestedKey])) {
+            result.requires[nestedKey].push(value);
+          }
+        } else {
+          if (!result[listKey]) result[listKey] = [];
+          if (Array.isArray(result[listKey])) {
+            result[listKey].push(value);
+          }
         }
         continue;
       }

--- a/src/skills/loader.ts
+++ b/src/skills/loader.ts
@@ -135,8 +135,11 @@ function validateInstructionContent(instructions: string, skillName: string): st
   for (const { pattern, label } of SUSPICIOUS_INSTRUCTION_PATTERNS) {
     if (pattern.test(sanitized)) {
       warnings.push(label);
-      // Strip the matched pattern
-      sanitized = sanitized.replace(pattern, `[REMOVED:${label}]`);
+      // Strip ALL occurrences of the matched pattern, not just the first.
+      // Without the 'g' flag, .replace() only strips the first match,
+      // allowing subsequent duplicates to pass through.
+      const globalPattern = new RegExp(pattern.source, pattern.flags.includes('g') ? pattern.flags : pattern.flags + 'g');
+      sanitized = sanitized.replace(globalPattern, `[REMOVED:${label}]`);
     }
   }
 


### PR DESCRIPTION
## Summary
- **YAML parser bug**: `parseYamlFrontmatter()` in `format.ts` stored list items (e.g., `requires.bins`) under a flat key like `result["requires.bins"]` instead of the nested `result.requires.bins`. This caused skill requirement checks to silently pass when they should have failed, since `checkRequirements()` reads from `skill.requires.bins`.
- **Sanitization bug**: `validateInstructionContent()` in `loader.ts` used `String.replace(regex, ...)` without the global flag, so only the **first** occurrence of each suspicious pattern was stripped. A skill with repeated injection patterns would bypass validation after the first match.

## Changes
- `src/skills/format.ts`: When accumulating list items under a `requires.*` key, check if `listKey` starts with `"requires."` and store directly into the nested `result.requires[nestedKey]` array instead of `result[listKey]`.
- `src/skills/loader.ts`: Construct a global-flag copy of each regex before calling `.replace()`, ensuring all occurrences are stripped.
- `src/__tests__/skills-hardening.test.ts`: Added 4 new tests covering nested YAML list parsing (`requires.bins`, `requires.env`) and global sanitization of repeated patterns.

## Test plan
- [x] `npx vitest run src/__tests__/skills-hardening.test.ts` — all 4 new tests pass
- [x] Full test suite passes (`npx vitest run`)
- [x] TypeScript compiles cleanly (`npx tsc --noEmit`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)