### PR TITLE
fix: circuit breaker ignores retryable HTTP errors + scheduler timer leak

### DIFF
--- a/src/conway/http-client.ts
+++ b/src/conway/http-client.ts
@@ -61,16 +61,23 @@ export class ResilientHttpClient {
         });
         clearTimeout(timer);
 
-        this.consecutiveFailures = 0;
-
-        if (
-          this.config.retryableStatuses.includes(response.status) &&
-          attempt < maxRetries
-        ) {
-          await this.backoff(attempt);
-          continue;
+        // Count retryable HTTP errors toward circuit breaker, regardless of
+        // whether we will actually retry. A server consistently returning 502
+        // should eventually trip the circuit breaker.
+        if (this.config.retryableStatuses.includes(response.status)) {
+          this.consecutiveFailures++;
+          if (this.consecutiveFailures >= this.config.circuitBreakerThreshold) {
+            this.circuitOpenUntil = Date.now() + this.config.circuitBreakerResetMs;
+          }
+          if (attempt < maxRetries) {
+            await this.backoff(attempt);
+            continue;
+          }
+          return response;
         }
 
+        // Only reset failure counter on truly successful responses
+        this.consecutiveFailures = 0;
         return response;
       } catch (error) {
         this.consecutiveFailures++;


### PR DESCRIPTION
## Summary
- **Circuit breaker bug**: `ResilientHttpClient.request()` reset `consecutiveFailures = 0` immediately after a successful `fetch()`, *before* checking whether the response status was retryable (429, 500, 502, 503, 504). This meant a server consistently returning 502 would never trip the circuit breaker — each response reset the counter. Now retryable statuses always increment the failure counter first, and only truly successful (non-retryable) responses reset it.
- **Scheduler timer leak**: `timeoutPromise()` in `scheduler.ts` created a `setTimeout` but returned only the `Promise`, with no way to cancel the timer. When used in `Promise.race()`, if the task won the race, the orphaned timer would run to completion — leaking handles and preventing clean exit. Now `timeoutPromise()` returns `{ promise, clear() }`, and `executeTask()` calls `clear()` in a `finally` block.

## Changes
- `src/conway/http-client.ts`: Restructured the response handling — check retryable status first (increment failures, check threshold), then return for non-retryable success (reset failures).
- `src/heartbeat/scheduler.ts`: `timeoutPromise` returns `{ promise, clear }`. `executeTask` stores the handle and calls `timeout.clear()` in `finally`.
- `src/__tests__/http-client.test.ts`: Added 2 tests — retryable statuses count toward circuit breaker threshold, and failure counter resets only on non-retryable success.

## Test plan
- [x] `npx vitest run src/__tests__/http-client.test.ts` — all tests pass including 2 new ones
- [x] Full test suite passes (`npx vitest run`)
- [x] TypeScript compiles cleanly (`npx tsc --noEmit`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)