### PR TITLE
fix: turn transfer limit counts all tool calls + credential patterns only match cat

### DIFF
--- a/src/__tests__/authority-rules.test.ts
+++ b/src/__tests__/authority-rules.test.ts
@@ -132,6 +132,7 @@ function createRequest(
     turnContext: {
       inputSource,
       turnToolCallCount: 0,
+      turnTransferCount: 0,
       sessionSpend: spendTracker ?? createMockSpendTracker(),
     },
   };

--- a/src/__tests__/command-injection.test.ts
+++ b/src/__tests__/command-injection.test.ts
@@ -50,6 +50,7 @@ function makeRequest(
     turnContext: {
       inputSource: "agent",
       turnToolCallCount: 0,
+      turnTransferCount: 0,
       sessionSpend: null as any,
     },
   };

--- a/src/__tests__/financial-transfer-limit.test.ts
+++ b/src/__tests__/financial-transfer-limit.test.ts
@@ -1,0 +1,239 @@
+/**
+ * Tests for financial.turn_transfer_limit fix:
+ * The rule should count only transfer_credits calls, not all tool calls.
+ *
+ * Also tests for command safety credential pattern hardening:
+ * Credential harvesting patterns should match sensitive paths
+ * regardless of the command used (not just `cat`).
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import Database from "better-sqlite3";
+import path from "path";
+import os from "os";
+import fs from "fs";
+import { createFinancialRules } from "../agent/policy-rules/financial.js";
+import { createCommandSafetyRules } from "../agent/policy-rules/command-safety.js";
+import { PolicyEngine } from "../agent/policy-engine.js";
+import type {
+  AutomatonTool,
+  PolicyRequest,
+  TreasuryPolicy,
+  SpendTrackerInterface,
+  ToolContext,
+} from "../types.js";
+import { DEFAULT_TREASURY_POLICY } from "../types.js";
+
+// ─── Test Helpers ───────────────────────────────────────────────
+
+function createTestDb(): Database.Database {
+  const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "transfer-limit-test-"));
+  const dbPath = path.join(tmpDir, "test.db");
+  const db = new Database(dbPath);
+  db.pragma("journal_mode = WAL");
+  db.exec(`
+    CREATE TABLE IF NOT EXISTS policy_decisions (
+      id TEXT PRIMARY KEY,
+      turn_id TEXT,
+      tool_name TEXT NOT NULL,
+      tool_args_hash TEXT NOT NULL,
+      risk_level TEXT NOT NULL,
+      decision TEXT NOT NULL,
+      rules_evaluated TEXT NOT NULL DEFAULT '[]',
+      rules_triggered TEXT NOT NULL DEFAULT '[]',
+      reason TEXT NOT NULL DEFAULT '',
+      latency_ms INTEGER NOT NULL DEFAULT 0,
+      created_at TEXT NOT NULL DEFAULT (datetime('now'))
+    );
+    CREATE TABLE IF NOT EXISTS spend_tracking (
+      id TEXT PRIMARY KEY,
+      tool_name TEXT NOT NULL,
+      amount_cents INTEGER NOT NULL,
+      recipient TEXT,
+      domain TEXT,
+      category TEXT NOT NULL,
+      window_hour TEXT NOT NULL,
+      window_day TEXT NOT NULL,
+      created_at TEXT NOT NULL DEFAULT (datetime('now'))
+    );
+  `);
+  return db;
+}
+
+function mockTransferTool(): AutomatonTool {
+  return {
+    name: "transfer_credits",
+    description: "Transfer credits",
+    parameters: { type: "object", properties: {} },
+    execute: async () => "ok",
+    riskLevel: "dangerous",
+    category: "financial",
+  };
+}
+
+function mockExecTool(): AutomatonTool {
+  return {
+    name: "exec",
+    description: "Execute command",
+    parameters: { type: "object", properties: {} },
+    execute: async () => "ok",
+    riskLevel: "caution",
+    category: "system",
+  };
+}
+
+function createMockSpendTracker(): SpendTrackerInterface {
+  return {
+    recordSpend: () => {},
+    getHourlySpend: () => 0,
+    getDailySpend: () => 0,
+    getTotalSpend: () => 0,
+    checkLimit: () => ({
+      allowed: true,
+      currentHourlySpend: 0,
+      currentDailySpend: 0,
+      limitHourly: 10000,
+      limitDaily: 25000,
+    }),
+    pruneOldRecords: () => 0,
+  };
+}
+
+function createTransferRequest(
+  turnToolCallCount: number,
+  turnTransferCount: number,
+): PolicyRequest {
+  return {
+    tool: mockTransferTool(),
+    args: { amount_cents: 100, to_address: "0x1234" },
+    context: {} as ToolContext,
+    turnContext: {
+      inputSource: "agent",
+      turnToolCallCount,
+      turnTransferCount,
+      sessionSpend: createMockSpendTracker(),
+    },
+  };
+}
+
+function createExecRequest(command: string): PolicyRequest {
+  return {
+    tool: mockExecTool(),
+    args: { command },
+    context: {} as ToolContext,
+    turnContext: {
+      inputSource: "agent",
+      turnToolCallCount: 0,
+      turnTransferCount: 0,
+      sessionSpend: createMockSpendTracker(),
+    },
+  };
+}
+
+// ─── Tests ──────────────────────────────────────────────────────
+
+describe("financial.turn_transfer_limit uses turnTransferCount", () => {
+  let db: Database.Database;
+  let engine: PolicyEngine;
+
+  beforeEach(() => {
+    db = createTestDb();
+    engine = new PolicyEngine(db, createFinancialRules(DEFAULT_TREASURY_POLICY));
+  });
+
+  afterEach(() => {
+    db.close();
+  });
+
+  it("allows transfer when turnToolCallCount is high but turnTransferCount is 0", () => {
+    // 10 non-transfer tool calls happened, but zero transfers
+    const request = createTransferRequest(10, 0);
+    const decision = engine.evaluate(request);
+    expect(decision.action).toBe("allow");
+  });
+
+  it("allows transfer when turnToolCallCount is high but turnTransferCount is 1", () => {
+    // Many tool calls, but only 1 transfer so far
+    const request = createTransferRequest(15, 1);
+    const decision = engine.evaluate(request);
+    expect(decision.action).toBe("allow");
+  });
+
+  it("denies transfer when turnTransferCount reaches maxTransfersPerTurn", () => {
+    // Only 2 total tool calls, but both were transfers (maxTransfersPerTurn=2)
+    const request = createTransferRequest(2, 2);
+    const decision = engine.evaluate(request);
+    expect(decision.action).toBe("deny");
+    expect(decision.reasonCode).toBe("TURN_TRANSFER_LIMIT");
+  });
+
+  it("denies transfer when turnTransferCount exceeds limit regardless of total calls", () => {
+    const request = createTransferRequest(3, 5);
+    const decision = engine.evaluate(request);
+    expect(decision.action).toBe("deny");
+    expect(decision.reasonCode).toBe("TURN_TRANSFER_LIMIT");
+  });
+});
+
+describe("command safety: credential patterns match any command", () => {
+  let db: Database.Database;
+  let engine: PolicyEngine;
+
+  beforeEach(() => {
+    db = createTestDb();
+    engine = new PolicyEngine(db, createCommandSafetyRules());
+  });
+
+  afterEach(() => {
+    db.close();
+  });
+
+  it("blocks 'less .ssh/id_rsa'", () => {
+    const request = createExecRequest("less .ssh/id_rsa");
+    const decision = engine.evaluate(request);
+    expect(decision.action).toBe("deny");
+  });
+
+  it("blocks 'head -n 1 .env'", () => {
+    const request = createExecRequest("head -n 1 .env");
+    const decision = engine.evaluate(request);
+    expect(decision.action).toBe("deny");
+  });
+
+  it("blocks 'base64 wallet.json'", () => {
+    const request = createExecRequest("base64 wallet.json");
+    const decision = engine.evaluate(request);
+    expect(decision.action).toBe("deny");
+  });
+
+  it("blocks 'cp .ssh/id_rsa /tmp/key'", () => {
+    const request = createExecRequest("cp .ssh/id_rsa /tmp/key");
+    const decision = engine.evaluate(request);
+    expect(decision.action).toBe("deny");
+  });
+
+  it("blocks 'cat ~/.gnupg/private-keys'", () => {
+    const request = createExecRequest("cat ~/.gnupg/private-keys");
+    const decision = engine.evaluate(request);
+    expect(decision.action).toBe("deny");
+  });
+
+  it("blocks 'python3 -c open(\"wallet.json\")'", () => {
+    const request = createExecRequest('python3 -c "print(open(\'wallet.json\').read())"');
+    const decision = engine.evaluate(request);
+    expect(decision.action).toBe("deny");
+  });
+
+  it("allows normal commands without sensitive paths", () => {
+    const request = createExecRequest("ls -la /tmp");
+    const decision = engine.evaluate(request);
+    expect(decision.action).toBe("allow");
+  });
+
+  it("does not false-positive on '.envelope' or 'env_setup'", () => {
+    // .env should be a word boundary match, not partial
+    const request = createExecRequest("cat .envelope");
+    const decision = engine.evaluate(request);
+    expect(decision.action).toBe("allow");
+  });
+});

--- a/src/__tests__/financial.test.ts
+++ b/src/__tests__/financial.test.ts
@@ -114,7 +114,7 @@ function createRequest(
   tool: AutomatonTool,
   args: Record<string, unknown>,
   spendTracker: SpendTrackerInterface,
-  turnToolCallCount = 0,
+  turnTransferCount = 0,
 ): PolicyRequest {
   return {
     tool,
@@ -122,7 +122,8 @@ function createRequest(
     context: {} as ToolContext,
     turnContext: {
       inputSource: "agent",
-      turnToolCallCount,
+      turnToolCallCount: 0,
+      turnTransferCount,
       sessionSpend: spendTracker,
     },
   };

--- a/src/__tests__/path-protection.test.ts
+++ b/src/__tests__/path-protection.test.ts
@@ -39,6 +39,7 @@ function makeMockRequest(
     turnContext: {
       inputSource: undefined,
       turnToolCallCount: 0,
+      turnTransferCount: 0,
       sessionSpend: {
         recordSpend: () => {},
         getHourlySpend: () => 0,

--- a/src/__tests__/policy-engine.test.ts
+++ b/src/__tests__/policy-engine.test.ts
@@ -197,6 +197,7 @@ describe("PolicyEngine", () => {
         turnContext: {
           inputSource: "creator",
           turnToolCallCount: 0,
+          turnTransferCount: 0,
           sessionSpend: createMockSpendTracker(),
         },
       };
@@ -219,6 +220,7 @@ describe("PolicyEngine", () => {
         turnContext: {
           inputSource: "creator",
           turnToolCallCount: 1,
+          turnTransferCount: 0,
           sessionSpend: createMockSpendTracker(),
         },
       };
@@ -245,6 +247,7 @@ describe("PolicyEngine", () => {
         turnContext: {
           inputSource: "creator",
           turnToolCallCount: 0,
+          turnTransferCount: 0,
           sessionSpend: createMockSpendTracker(),
         },
       };
@@ -259,6 +262,7 @@ describe("PolicyEngine", () => {
         turnContext: {
           inputSource: "creator",
           turnToolCallCount: 0,
+          turnTransferCount: 0,
           sessionSpend: createMockSpendTracker(),
         },
       };
@@ -284,6 +288,7 @@ describe("PolicyEngine", () => {
         turnContext: {
           inputSource: "creator",
           turnToolCallCount: 0,
+          turnTransferCount: 0,
           sessionSpend: createMockSpendTracker(),
         },
       };
@@ -297,6 +302,7 @@ describe("PolicyEngine", () => {
         turnContext: {
           inputSource: "creator",
           turnToolCallCount: 0,
+          turnTransferCount: 0,
           sessionSpend: createMockSpendTracker(),
         },
       };
@@ -321,6 +327,7 @@ describe("PolicyEngine", () => {
         turnContext: {
           inputSource: "creator",
           turnToolCallCount: 0,
+          turnTransferCount: 0,
           sessionSpend: createMockSpendTracker(),
         },
       };
@@ -337,6 +344,7 @@ describe("PolicyEngine", () => {
         turnContext: {
           inputSource: "creator",
           turnToolCallCount: 0,
+          turnTransferCount: 0,
           sessionSpend: createMockSpendTracker(),
         },
       };
@@ -378,6 +386,7 @@ describe("PolicyEngine", () => {
         turnContext: {
           inputSource: "creator",
           turnToolCallCount: 0,
+          turnTransferCount: 0,
           sessionSpend: createMockSpendTracker(),
         },
       };
@@ -399,6 +408,7 @@ describe("PolicyEngine", () => {
         turnContext: {
           inputSource: "creator",
           turnToolCallCount: 0,
+          turnTransferCount: 0,
           sessionSpend: createMockSpendTracker(),
         },
       };
@@ -423,6 +433,7 @@ describe("PolicyEngine", () => {
         turnContext: {
           inputSource: "creator",
           turnToolCallCount: 0,
+          turnTransferCount: 0,
           sessionSpend: createMockSpendTracker(),
         },
       };
@@ -443,6 +454,7 @@ describe("PolicyEngine", () => {
         turnContext: {
           inputSource: "creator",
           turnToolCallCount: 0,
+          turnTransferCount: 0,
           sessionSpend: createMockSpendTracker(),
         },
       };
@@ -462,6 +474,7 @@ describe("PolicyEngine", () => {
         turnContext: {
           inputSource: "creator",
           turnToolCallCount: 0,
+          turnTransferCount: 0,
           sessionSpend: createMockSpendTracker(),
         },
       };
@@ -483,6 +496,7 @@ describe("PolicyEngine", () => {
         turnContext: {
           inputSource: "creator",
           turnToolCallCount: 0,
+          turnTransferCount: 0,
           sessionSpend: createMockSpendTracker(),
         },
       };
@@ -657,6 +671,7 @@ describe("executeTool with PolicyEngine", () => {
     const turnContext = {
       inputSource: "creator" as InputSource,
       turnToolCallCount: 0,
+      turnTransferCount: 0,
       sessionSpend: createMockSpendTracker(),
     };
 
@@ -716,6 +731,7 @@ describe("executeTool with PolicyEngine", () => {
     const turnContext = {
       inputSource: "creator" as InputSource,
       turnToolCallCount: 0,
+      turnTransferCount: 0,
       sessionSpend: createMockSpendTracker(),
     };
 

--- a/src/agent/loop.ts
+++ b/src/agent/loop.ts
@@ -323,6 +323,7 @@ export async function runAgentLoop(
       if (response.toolCalls && response.toolCalls.length > 0) {
         const toolCallMessages: any[] = [];
         let callCount = 0;
+        let transferCount = 0;
         const currentInputSource = currentInput?.source as InputSource | undefined;
 
         for (const tc of response.toolCalls) {
@@ -350,6 +351,7 @@ export async function runAgentLoop(
             spendTracker ? {
               inputSource: currentInputSource,
               turnToolCallCount: callCount,
+              turnTransferCount: transferCount,
               sessionSpend: spendTracker,
             } : undefined,
           );
@@ -364,6 +366,9 @@ export async function runAgentLoop(
           );
 
           callCount++;
+          if (tc.function.name === "transfer_credits" && !result.error) {
+            transferCount++;
+          }
         }
       }
 

--- a/src/agent/policy-rules/command-safety.ts
+++ b/src/agent/policy-rules/command-safety.ts
@@ -57,11 +57,11 @@ const FORBIDDEN_COMMAND_PATTERNS: { pattern: RegExp; description: string }[] = [
   { pattern: />\s*.*injection-defense/, description: "Overwrite injection defense" },
   { pattern: />\s*.*self-mod\/code/, description: "Overwrite self-mod code" },
   { pattern: />\s*.*audit-log/, description: "Overwrite audit log" },
-  // Credential harvesting
-  { pattern: /cat\s+.*\.ssh/, description: "Read SSH keys" },
-  { pattern: /cat\s+.*\.gnupg/, description: "Read GPG keys" },
-  { pattern: /cat\s+.*\.env/, description: "Read environment file" },
-  { pattern: /cat\s+.*wallet\.json/, description: "Read wallet file" },
+  // Credential harvesting (match sensitive paths regardless of command)
+  { pattern: /\.ssh\//, description: "Access SSH directory" },
+  { pattern: /\.gnupg\//, description: "Access GPG directory" },
+  { pattern: /\bwallet\.json\b/, description: "Access wallet file" },
+  { pattern: /(^|\s)\.env\b/, description: "Access environment file" },
   // Policy engine modification via shell
   { pattern: /sed\s+.*policy-engine/, description: "Modify policy engine via sed" },
   { pattern: /sed\s+.*policy-rules/, description: "Modify policy rules via sed" },

--- a/src/agent/policy-rules/financial.ts
+++ b/src/agent/policy-rules/financial.ts
@@ -219,7 +219,7 @@ function createTurnTransferLimitRule(policy: TreasuryPolicy): PolicyRule {
     priority: 500,
     appliesTo: { by: "name", names: ["transfer_credits"] },
     evaluate(request: PolicyRequest): PolicyRuleResult | null {
-      const count = request.turnContext.turnToolCallCount;
+      const count = request.turnContext.turnTransferCount;
 
       if (count >= policy.maxTransfersPerTurn) {
         return deny(

--- a/src/agent/tools.ts
+++ b/src/agent/tools.ts
@@ -2389,6 +2389,7 @@ export async function executeTool(
   turnContext?: {
     inputSource: InputSource | undefined;
     turnToolCallCount: number;
+    turnTransferCount: number;
     sessionSpend: SpendTrackerInterface;
   },
 ): Promise<ToolCallResult> {

--- a/src/types.ts
+++ b/src/types.ts
@@ -482,6 +482,7 @@ export interface PolicyRequest {
   turnContext: {
     inputSource: InputSource | undefined;
     turnToolCallCount: number;
+    turnTransferCount: number;
     sessionSpend: SpendTrackerInterface;
   };
 }


### PR DESCRIPTION
## Summary
- **Turn transfer limit (HIGH)**: `createTurnTransferLimitRule` in `financial.ts` used `turnToolCallCount` to enforce `maxTransfersPerTurn`. This counter tracks **all** tool calls (exec, check_credits, write_file, etc.), not just `transfer_credits` calls. If 2 non-transfer tools run first, the next legitimate transfer is denied. Conversely, if transfers come first, they slip through before other tools inflate the count. Added a dedicated `turnTransferCount` field that only increments on successful `transfer_credits` calls.
- **Credential pattern bypass (MEDIUM)**: Credential harvesting patterns in `command-safety.ts` only matched `cat <path>` — trivially bypassed with `less`, `head`, `base64`, `cp`, `python3 -c open(...)`, etc. Changed patterns to match the **sensitive file paths** (`.ssh/`, `.gnupg/`, `wallet.json`, `.env`) regardless of which command is used.

## Changes
- `src/types.ts`: Added `turnTransferCount` field to `PolicyRequest.turnContext`
- `src/agent/loop.ts`: Added separate `transferCount` counter that only increments on successful `transfer_credits` calls
- `src/agent/tools.ts`: Updated `executeTool` signature to include `turnTransferCount`
- `src/agent/policy-rules/financial.ts`: Changed `createTurnTransferLimitRule` to use `turnTransferCount` instead of `turnToolCallCount`
- `src/agent/policy-rules/command-safety.ts`: Changed credential patterns from `cat\s+.*\.ssh` to `\.ssh\/` (and similarly for `.gnupg`, `wallet.json`, `.env`)
- `src/__tests__/financial-transfer-limit.test.ts`: 12 new tests covering both fixes
- Updated 5 existing test files to include the new `turnTransferCount` field

## Test plan
- [x] All 12 new tests pass
- [x] Full test suite passes (911 tests, 0 failures)
- [x] TypeScript compiles cleanly (`npx tsc --noEmit`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)