### PR TITLE
fix: survival tier gate, x402 paid retry timeout, ingestion count inflation

### DIFF
--- a/src/__tests__/low-compute.test.ts
+++ b/src/__tests__/low-compute.test.ts
@@ -1,0 +1,114 @@
+import { describe, it, expect, vi } from "vitest";
+import {
+  canRunInference,
+  getModelForTier,
+  applyTierRestrictions,
+} from "../survival/low-compute.js";
+import type { SurvivalTier } from "../types.js";
+
+describe("canRunInference", () => {
+  it("allows inference for 'high' tier", () => {
+    expect(canRunInference("high")).toBe(true);
+  });
+
+  it("allows inference for 'normal' tier", () => {
+    expect(canRunInference("normal")).toBe(true);
+  });
+
+  it("allows inference for 'low_compute' tier", () => {
+    expect(canRunInference("low_compute")).toBe(true);
+  });
+
+  it("allows inference for 'critical' tier", () => {
+    expect(canRunInference("critical")).toBe(true);
+  });
+
+  it("denies inference for 'dead' tier", () => {
+    expect(canRunInference("dead")).toBe(false);
+  });
+});
+
+describe("getModelForTier", () => {
+  const defaultModel = "gpt-5.2";
+
+  it("returns default model for 'high' tier", () => {
+    expect(getModelForTier("high", defaultModel)).toBe(defaultModel);
+  });
+
+  it("returns default model for 'normal' tier", () => {
+    expect(getModelForTier("normal", defaultModel)).toBe(defaultModel);
+  });
+
+  it("returns a cheaper model for 'low_compute' tier", () => {
+    const model = getModelForTier("low_compute", defaultModel);
+    expect(model).not.toBe(defaultModel);
+  });
+
+  it("returns a cheaper model for 'critical' tier", () => {
+    const model = getModelForTier("critical", defaultModel);
+    expect(model).not.toBe(defaultModel);
+  });
+
+  it("returns a value for every tier", () => {
+    const tiers: SurvivalTier[] = ["high", "normal", "low_compute", "critical", "dead"];
+    for (const tier of tiers) {
+      const model = getModelForTier(tier, defaultModel);
+      expect(model).toBeTruthy();
+    }
+  });
+});
+
+describe("applyTierRestrictions", () => {
+  function makeMocks() {
+    return {
+      inference: { setLowComputeMode: vi.fn() },
+      db: {
+        setKV: vi.fn(),
+        getKV: vi.fn(),
+        raw: {} as any,
+        insertTurn: vi.fn(),
+        updateTurn: vi.fn(),
+        getTurnsBySession: vi.fn(),
+        insertToolCall: vi.fn(),
+        getToolCallsByTurn: vi.fn(),
+        getChildById: vi.fn(),
+        getChildren: vi.fn(),
+        insertChild: vi.fn(),
+        updateChild: vi.fn(),
+        deleteChild: vi.fn(),
+        close: vi.fn(),
+      },
+    };
+  }
+
+  it("sets low compute mode off for 'high' tier", () => {
+    const { inference, db } = makeMocks();
+    applyTierRestrictions("high", inference as any, db as any);
+    expect(inference.setLowComputeMode).toHaveBeenCalledWith(false);
+    expect(db.setKV).toHaveBeenCalledWith("current_tier", "high");
+  });
+
+  it("sets low compute mode off for 'normal' tier", () => {
+    const { inference, db } = makeMocks();
+    applyTierRestrictions("normal", inference as any, db as any);
+    expect(inference.setLowComputeMode).toHaveBeenCalledWith(false);
+  });
+
+  it("sets low compute mode on for 'low_compute' tier", () => {
+    const { inference, db } = makeMocks();
+    applyTierRestrictions("low_compute", inference as any, db as any);
+    expect(inference.setLowComputeMode).toHaveBeenCalledWith(true);
+  });
+
+  it("sets low compute mode on for 'critical' tier", () => {
+    const { inference, db } = makeMocks();
+    applyTierRestrictions("critical", inference as any, db as any);
+    expect(inference.setLowComputeMode).toHaveBeenCalledWith(true);
+  });
+
+  it("sets low compute mode on for 'dead' tier", () => {
+    const { inference, db } = makeMocks();
+    applyTierRestrictions("dead", inference as any, db as any);
+    expect(inference.setLowComputeMode).toHaveBeenCalledWith(true);
+  });
+});

--- a/src/agent/tools.ts
+++ b/src/agent/tools.ts
@@ -2290,13 +2290,15 @@ Model: ${ctx.inference.getDefaultModel()}
           ? JSON.parse(args.headers as string)
           : undefined;
 
+        const maxPayment = ctx.config.treasuryPolicy?.maxX402PaymentCents
+          ?? DEFAULT_TREASURY_POLICY.maxX402PaymentCents;
         const result = await x402Fetch(
           url,
           ctx.identity.account,
           method,
           body,
           extraHeaders,
-          DEFAULT_TREASURY_POLICY.maxX402PaymentCents,
+          maxPayment,
         );
 
         if (!result.success) {

--- a/src/conway/x402.ts
+++ b/src/conway/x402.ts
@@ -334,7 +334,7 @@ export async function x402Fetch(
       JSON.stringify(payment),
     ).toString("base64");
 
-    const paidResp = await fetch(url, {
+    const paidResp = await x402HttpClient.request(url, {
       method,
       headers: {
         ...headers,
@@ -342,6 +342,7 @@ export async function x402Fetch(
         "X-Payment": paymentHeader,
       },
       body,
+      retries: 0, // Paid request: do not auto-retry (payment already signed)
     });
 
     const data = await paidResp.json().catch(() => paidResp.text());

--- a/src/survival/low-compute.ts
+++ b/src/survival/low-compute.ts
@@ -28,6 +28,10 @@ export function applyTierRestrictions(
   db: AutomatonDatabase,
 ): void {
   switch (tier) {
+    case "high":
+      inference.setLowComputeMode(false);
+      break;
+
     case "normal":
       inference.setLowComputeMode(false);
       break;
@@ -86,7 +90,7 @@ export function recordTransition(
  * Check if the agent should be allowed to run inference in current tier.
  */
 export function canRunInference(tier: SurvivalTier): boolean {
-  return tier === "normal" || tier === "low_compute" || tier === "critical";
+  return tier === "high" || tier === "normal" || tier === "low_compute" || tier === "critical";
 }
 
 /**


### PR DESCRIPTION
## Summary

Four correctness bugs across survival, x402 payment, tool configuration, and memory ingestion.

### Fix 1: `canRunInference()` and `applyTierRestrictions()` omit "high" tier — `src/survival/low-compute.ts`

The `"high"` survival tier (credits > $5.00) was missing from both `canRunInference()` and the `applyTierRestrictions()` switch statement. Agents at the healthiest credit level were erroneously denied inference and never had low-compute mode configured.

### Fix 2: x402 paid retry uses raw `fetch()` with no timeout — `src/conway/x402.ts`

The initial 402 probe uses `x402HttpClient.request()` (with circuit breaker, timeout, and retries), but the critical paid retry — where USDC is already signed and sent — used bare `fetch()` with no timeout or circuit breaker protection. If the server hangs after receiving the signed payment, the agent blocks indefinitely while the money is gone. Switched to `x402HttpClient.request()` with `retries: 0` since the payment is already signed and should not be retried.

### Fix 3: `x402_fetch` tool ignores configured treasury policy — `src/agent/tools.ts`

The `x402_fetch` tool hardcoded `DEFAULT_TREASURY_POLICY.maxX402PaymentCents` instead of reading `ctx.config.treasuryPolicy?.maxX402PaymentCents`. If an operator configured a custom max x402 payment limit in `automaton.json`, it was silently ignored.

### Fix 4: Inbox sender interaction tracked N times per turn — `src/memory/ingestion.ts`

`updateRelationships()` checked `turn.inputSource` and `turn.input` inside the `for (const tc of toolCallResults)` loop. Since these are turn-level properties (not per-tool-call), a turn with N tool calls would record the same inbox sender N times, inflating `interaction_count` in relationship memory.

## Changes

| File | Change |
|------|--------|
| `src/survival/low-compute.ts` | Add `"high"` case to `applyTierRestrictions()` and `canRunInference()` |
| `src/conway/x402.ts` | Use `x402HttpClient.request()` for paid retry with `retries: 0` |
| `src/agent/tools.ts` | Read `maxX402PaymentCents` from `ctx.config.treasuryPolicy` with fallback |
| `src/memory/ingestion.ts` | Move inbox sender tracking outside tool-call loop |
| `src/__tests__/low-compute.test.ts` | New: 15 tests for survival tier functions |
| `src/__tests__/memory.test.ts` | Add test verifying inbox interaction is recorded once per turn |

## Test plan

- [x] `npx tsc --noEmit` — zero type errors
- [x] `npx vitest run` — 938 tests pass (25 files)
- [x] New test: `canRunInference("high")` returns `true`
- [x] New test: `applyTierRestrictions("high")` sets low-compute mode off
- [x] New test: inbox sender interaction count not inflated by tool call count

🤖 Generated with [Claude Code](https://claude.com/claude-code)