### PR TITLE
fix: reject invalid timestamps in social message validation

### DIFF
--- a/src/__tests__/social.test.ts
+++ b/src/__tests__/social.test.ts
@@ -194,6 +194,20 @@ describe("Message Validation", () => {
     expect(result.errors.some((e) => e.includes("future"))).toBe(true);
   });
 
+  it("invalid timestamp string is rejected", async () => {
+    const { validateMessage } = await import("../social/validation.js");
+
+    const result = validateMessage({
+      from: "0x70997970C51812dc3A010C7d01b50e0d17dc79C8",
+      to: "0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266",
+      content: "Hello!",
+      signed_at: "not-a-valid-date",
+    });
+
+    expect(result.valid).toBe(false);
+    expect(result.errors.some((e) => e.includes("Invalid timestamp"))).toBe(true);
+  });
+
   it("invalid from address fails", async () => {
     const { validateMessage } = await import("../social/validation.js");
 

--- a/src/social/validation.ts
+++ b/src/social/validation.ts
@@ -34,12 +34,17 @@ export function validateMessage(message: {
   // Timestamp validation (replay protection)
   const ts = message.signed_at || message.timestamp;
   if (ts) {
-    const age = Date.now() - new Date(ts).getTime();
-    if (age > MESSAGE_LIMITS.replayWindowMs) {
-      errors.push("Message too old (possible replay)");
-    }
-    if (age < -60_000) {
-      errors.push("Message from future");
+    const parsed = new Date(ts).getTime();
+    if (isNaN(parsed)) {
+      errors.push("Invalid timestamp");
+    } else {
+      const age = Date.now() - parsed;
+      if (age > MESSAGE_LIMITS.replayWindowMs) {
+        errors.push("Message too old (possible replay)");
+      }
+      if (age < -60_000) {
+        errors.push("Message from future");
+      }
     }
   }
 


### PR DESCRIPTION
## Summary
- Invalid date strings (e.g. `"not-a-valid-date"`) passed to `validateMessage()` produce `NaN` from `Date.getTime()`, causing both replay-protection and future-message checks to silently pass (`NaN > number` is always `false`)
- Added an explicit `isNaN` guard so malformed timestamps are rejected with an `"Invalid timestamp"` error instead of bypassing validation
- Added test case for invalid timestamp rejection

## Test plan
- [x] `npx tsc --noEmit` passes
- [x] All 51 social tests pass including new invalid timestamp test