### PR TITLE
fix: use nullish coalescing for numeric heartbeat config fields

### DIFF
--- a/src/__tests__/heartbeat-scheduler.test.ts
+++ b/src/__tests__/heartbeat-scheduler.test.ts
@@ -440,4 +440,27 @@ describe("DurableScheduler", () => {
       fs.rmSync(tmpDir, { recursive: true });
     });
   });
+
+  describe("numeric config field zero values", () => {
+    it("preserves explicit zero for defaultIntervalMs and lowComputeMultiplier", async () => {
+      const { loadHeartbeatConfig } = await import("../heartbeat/config.js");
+      const fs = await import("fs");
+      const path = await import("path");
+      const os = await import("os");
+      const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "hb-zero-test-"));
+      const configPath = path.join(tmpDir, "heartbeat.yml");
+
+      // YAML with explicit zero values
+      fs.writeFileSync(configPath, "defaultIntervalMs: 0\nlowComputeMultiplier: 0\n");
+
+      const config = loadHeartbeatConfig(configPath);
+
+      // With ||, 0 is falsy and would fall back to defaults (60000, 4).
+      // With ??, 0 is preserved as the user-specified value.
+      expect(config.defaultIntervalMs).toBe(0);
+      expect(config.lowComputeMultiplier).toBe(0);
+
+      fs.rmSync(tmpDir, { recursive: true });
+    });
+  });
 });

--- a/src/heartbeat/config.ts
+++ b/src/heartbeat/config.ts
@@ -88,9 +88,9 @@ export function loadHeartbeatConfig(configPath?: string): HeartbeatConfig {
     return {
       entries,
       defaultIntervalMs:
-        parsed.defaultIntervalMs || DEFAULT_HEARTBEAT_CONFIG.defaultIntervalMs,
+        parsed.defaultIntervalMs ?? DEFAULT_HEARTBEAT_CONFIG.defaultIntervalMs,
       lowComputeMultiplier:
-        parsed.lowComputeMultiplier ||
+        parsed.lowComputeMultiplier ??
         DEFAULT_HEARTBEAT_CONFIG.lowComputeMultiplier,
     };
   } catch (error: any) {


### PR DESCRIPTION
## Summary
- `loadHeartbeatConfig()` uses `||` for `defaultIntervalMs` and `lowComputeMultiplier`, which treats `0` as falsy and silently reverts to defaults
- Setting `defaultIntervalMs: 0` in heartbeat.yml produces `60000` instead of `0`; `lowComputeMultiplier: 0` produces `4` instead of `0`
- Replace `||` with `??` so explicit zero values are preserved

## Changes
- **src/heartbeat/config.ts**: `||` → `??` for both numeric fields
- **src/__tests__/heartbeat-scheduler.test.ts**: Added test verifying explicit zero values are preserved

## Test plan
- [x] `npx tsc --noEmit` passes
- [x] All 20 heartbeat-scheduler tests pass including new zero-value test