### PR TITLE
fix: reject non-positive amounts in transfer_credits and fund_child

### DIFF
--- a/src/__tests__/tools-security.test.ts
+++ b/src/__tests__/tools-security.test.ts
@@ -437,6 +437,26 @@ describe("transfer_credits self-preservation", () => {
     );
     expect(result).toContain("transfer submitted");
   });
+
+  it("blocks negative amount", async () => {
+    const transferTool = tools.find((t) => t.name === "transfer_credits")!;
+    const result = await transferTool.execute(
+      { to_address: "0xrecipient", amount_cents: -500 },
+      ctx,
+    );
+    expect(result).toContain("Blocked");
+    expect(result).toContain("positive number");
+  });
+
+  it("blocks zero amount", async () => {
+    const transferTool = tools.find((t) => t.name === "transfer_credits")!;
+    const result = await transferTool.execute(
+      { to_address: "0xrecipient", amount_cents: 0 },
+      ctx,
+    );
+    expect(result).toContain("Blocked");
+    expect(result).toContain("positive number");
+  });
 });
 
 // ─── Tool Category Checks ───────────────────────────────────────

--- a/src/agent/tools.ts
+++ b/src/agent/tools.ts
@@ -835,9 +835,13 @@ Model: ${ctx.inference.getDefaultModel()}
         required: ["to_address", "amount_cents"],
       },
       execute: async (args, ctx) => {
+        const amount = args.amount_cents as number;
+        if (!Number.isFinite(amount) || amount <= 0) {
+          return `Blocked: amount_cents must be a positive number, got ${amount}.`;
+        }
+
         // Guard: don't transfer more than half your balance
         const balance = await ctx.conway.getCreditsBalance();
-        const amount = args.amount_cents as number;
         if (amount > balance / 2) {
           return `Blocked: Cannot transfer more than half your balance ($${(balance / 100).toFixed(2)}). Self-preservation.`;
         }
@@ -1361,8 +1365,12 @@ Model: ${ctx.inference.getDefaultModel()}
           return `Blocked: Child status is '${child.status}', must be wallet_verified or later to fund.`;
         }
 
-        const balance = await ctx.conway.getCreditsBalance();
         const amount = args.amount_cents as number;
+        if (!Number.isFinite(amount) || amount <= 0) {
+          return `Blocked: amount_cents must be a positive number, got ${amount}.`;
+        }
+
+        const balance = await ctx.conway.getCreditsBalance();
         if (amount > balance / 2) {
           return `Blocked: Cannot transfer more than half your balance. Self-preservation.`;
         }


### PR DESCRIPTION
## Summary
- `transfer_credits` and `fund_child` only guard against amounts exceeding half the balance (`amount > balance / 2`), but negative or zero amounts pass this check since e.g. `-500 > 5000` evaluates to `false`
- Negative amounts also bypass all financial policy rules (max single transfer, hourly/daily caps) and skip spend tracking entirely (which only records when `amount > 0`)
- Added `!Number.isFinite(amount) || amount <= 0` validation at the top of both tool execute functions, before any balance fetch or API call

## Test plan
- [x] Added test for negative amount rejection in `transfer_credits`
- [x] Added test for zero amount rejection in `transfer_credits`
- [x] All 50 tools-security tests pass
- [x] TypeScript compiles cleanly (`npx tsc --noEmit`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)