### PR TITLE
fix: blocked inbox messages should not wake the agent

### DIFF
--- a/src/heartbeat/tasks.ts
+++ b/src/heartbeat/tasks.ts
@@ -204,13 +204,16 @@ export const BUILTIN_TASKS: Record<string, HeartbeatTaskFn> = {
         const sanitizedMsg = {
           ...msg,
           from: sanitizedFrom.content,
-          content: sanitizedContent.blocked
-            ? sanitizedContent.content
-            : sanitizedContent.content,
+          content: sanitizedContent.content,
         };
         taskCtx.db.insertInboxMessage(sanitizedMsg);
         taskCtx.db.setKV(`inbox_seen_${msg.id}`, "1");
-        newCount++;
+        // Only count non-blocked messages toward wake threshold —
+        // blocked messages are stored for audit but should not wake
+        // the agent (prevents injection spam from draining credits).
+        if (!sanitizedContent.blocked) {
+          newCount++;
+        }
       }
     }
 


### PR DESCRIPTION
## Summary
- `check_social_inbox` in `tasks.ts` had a dead ternary where both branches of `sanitizedContent.blocked ? sanitizedContent.content : sanitizedContent.content` returned the same value
- More importantly, blocked messages (injection attempts, oversized payloads) still incremented `newCount`, causing `shouldWake: true` — an attacker could spam blocked messages to repeatedly wake the agent, draining compute credits
- Fixed the dead ternary and moved the `newCount++` inside a `!sanitizedContent.blocked` guard so blocked messages are stored for audit but don't trigger a wake

## Test plan
- [x] Added test verifying oversized (blocked) messages are stored but `shouldWake` returns `false`
- [x] All 19 heartbeat tests pass
- [x] TypeScript compiles cleanly (`npx tsc --noEmit`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)