### PR TITLE
fix: per-tier funding cooldown keys to prevent notification suppression

### DIFF
--- a/src/__tests__/funding.test.ts
+++ b/src/__tests__/funding.test.ts
@@ -1,0 +1,98 @@
+/**
+ * Funding Strategy Tests
+ *
+ * Tests for executeFundingStrategies, especially per-tier cooldown isolation.
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { executeFundingStrategies } from "../survival/funding.js";
+import {
+  MockConwayClient,
+  createTestDb,
+  createTestIdentity,
+  createTestConfig,
+} from "./mocks.js";
+import type { AutomatonDatabase } from "../types.js";
+
+describe("executeFundingStrategies", () => {
+  let db: AutomatonDatabase;
+  let conway: MockConwayClient;
+
+  beforeEach(() => {
+    db = createTestDb();
+    conway = new MockConwayClient();
+    conway.creditsCents = 5; // low balance
+  });
+
+  afterEach(() => {
+    db.close();
+  });
+
+  it("dead-tier cooldown does not suppress low_compute notification", async () => {
+    const identity = createTestIdentity();
+    const config = createTestConfig();
+
+    // First: trigger dead-tier plea
+    const deadAttempts = await executeFundingStrategies(
+      "dead",
+      identity,
+      config,
+      db,
+      conway,
+    );
+    expect(deadAttempts.length).toBe(1);
+    expect(deadAttempts[0].strategy).toBe("desperate_plea");
+
+    // Now: agent recovers to low_compute. With the fix, the low_compute
+    // notification should fire because it has its own cooldown key.
+    const lowAttempts = await executeFundingStrategies(
+      "low_compute",
+      identity,
+      config,
+      db,
+      conway,
+    );
+    expect(lowAttempts.length).toBe(1);
+    expect(lowAttempts[0].strategy).toBe("polite_creator_notification");
+  });
+
+  it("critical-tier cooldown does not suppress low_compute notification", async () => {
+    const identity = createTestIdentity();
+    const config = createTestConfig();
+
+    // Trigger critical-tier notice
+    const criticalAttempts = await executeFundingStrategies(
+      "critical",
+      identity,
+      config,
+      db,
+      conway,
+    );
+    expect(criticalAttempts.length).toBe(1);
+    expect(criticalAttempts[0].strategy).toBe("urgent_local_notice");
+
+    // low_compute should still fire independently
+    const lowAttempts = await executeFundingStrategies(
+      "low_compute",
+      identity,
+      config,
+      db,
+      conway,
+    );
+    expect(lowAttempts.length).toBe(1);
+    expect(lowAttempts[0].strategy).toBe("polite_creator_notification");
+  });
+
+  it("respects per-tier cooldown on repeated calls", async () => {
+    const identity = createTestIdentity();
+    const config = createTestConfig();
+
+    // First dead-tier call fires
+    const first = await executeFundingStrategies("dead", identity, config, db, conway);
+    expect(first.length).toBe(1);
+
+    // Immediate second dead-tier call should be suppressed (2h cooldown)
+    const second = await executeFundingStrategies("dead", identity, config, db, conway);
+    expect(second.length).toBe(0);
+  });
+});


### PR DESCRIPTION
## Summary
- `executeFundingStrategies` uses a single `last_funding_request` KV key for all three survival tier cooldowns (low_compute: 24h, critical: 6h, dead: 2h)
- When the dead-tier plea fires (every 2h), it resets the shared timer — if the agent then recovers to `low_compute`, the polite creator notification is suppressed because `hoursSinceLastBeg` is only ~2h, well under the 24h threshold
- An agent that yo-yos between `dead` and `low_compute` (small topups arriving, then draining) will never trigger the `low_compute` early warning, silently starving without the creator seeing the earliest notification
- Fixed by using per-tier keys (`last_funding_request_<tier>`) so each tier tracks its own cooldown independently

## Test plan
- [x] Added test: dead-tier cooldown does not suppress low_compute notification
- [x] Added test: critical-tier cooldown does not suppress low_compute notification
- [x] Added test: per-tier cooldown is respected on repeated same-tier calls
- [x] All 3 new funding tests pass
- [x] TypeScript compiles cleanly (`npx tsc --noEmit`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)