### PR TITLE
fix: social rate limit counts only successful sends, not attempts

### DIFF
--- a/src/__tests__/social.test.ts
+++ b/src/__tests__/social.test.ts
@@ -338,6 +338,39 @@ describe("Social Client", () => {
 
     vi.unstubAllGlobals();
   });
+
+  it("rate limiting: failed sends count toward the hourly limit", async () => {
+    const { createSocialClient } = await import("../social/client.js");
+    const { privateKeyToAccount } = await import("viem/accounts");
+    const account = privateKeyToAccount(
+      "0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80",
+    );
+
+    // Server returns 500 for every request
+    const mockFetch = vi.fn().mockResolvedValue({
+      ok: false,
+      status: 500,
+      statusText: "Internal Server Error",
+      json: () => Promise.resolve({ error: "server error" }),
+    });
+    vi.stubGlobal("fetch", mockFetch);
+
+    const client = createSocialClient("https://relay.example.com", account);
+
+    // Send 100 messages that all fail with 500
+    for (let i = 0; i < 100; i++) {
+      await client
+        .send("0x70997970C51812dc3A010C7d01b50e0d17dc79C8", `msg ${i}`)
+        .catch(() => {}); // ignore the send failure
+    }
+
+    // 101st should be rate-limited even though all previous sends failed
+    await expect(
+      client.send("0x70997970C51812dc3A010C7d01b50e0d17dc79C8", "msg 100"),
+    ).rejects.toThrow("Rate limit exceeded");
+
+    vi.unstubAllGlobals();
+  });
 });
 
 // ─── 5. Agent Card Tests ────────────────────────────────────────

--- a/src/social/client.ts
+++ b/src/social/client.ts
@@ -83,6 +83,11 @@ export function createSocialClient(
       // Phase 3.2: Rate limit check
       checkRateLimit();
 
+      // Track outbound attempt for rate limiting BEFORE the network call.
+      // Counting attempts (not just successes) prevents hammering the relay
+      // with unlimited retries when the server returns errors.
+      outboundTimestamps.push(Date.now());
+
       // Phase 3.2: Validate message before sending
       const validation = validateMessage({ from: account.address, to, content });
       if (!validation.valid) {
@@ -105,9 +110,6 @@ export function createSocialClient(
           `Send failed (${res.status}): ${(err as any).error || res.statusText}`,
         );
       }
-
-      // Track outbound for rate limiting
-      outboundTimestamps.push(Date.now());
 
       const data = (await res.json()) as { id: string };
       return { id: data.id };


### PR DESCRIPTION
## Summary
- The social client's outbound rate limiter (`outboundTimestamps.push()`) was placed after the HTTP response check, so failed sends (500, 429, network errors) never increment the counter
- An agent retrying against a failing relay can send unlimited requests without hitting the local hourly cap (`maxOutboundPerHour = 100`)
- Moved the timestamp push before the network call so every send attempt counts toward the rate limit

## Test plan
- [x] Added test verifying that 100 failed sends (HTTP 500) still trigger rate limit on the 101st attempt
- [x] All 51 social tests pass
- [x] TypeScript compiles cleanly (`npx tsc --noEmit`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)