### PR TITLE
fix: installer script fails on non-root and misuses npm instead of pnpm

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,6 +49,7 @@
     "clean": "rm -rf dist && pnpm -r clean"
   },
   "dependencies": {
+    "@types/better-sqlite3": "^7.6.0",
     "better-sqlite3": "^11.0.0",
     "chalk": "^5.3.0",
     "cron-parser": "^4.9.0",
@@ -61,7 +62,6 @@
     "yaml": "^2.4.0"
   },
   "devDependencies": {
-    "@types/better-sqlite3": "^7.6.0",
     "@types/node": "^20.10.0",
     "tsx": "^4.7.0",
     "typescript": "^5.9.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,6 +8,9 @@ importers:
 
   .:
     dependencies:
+      '@types/better-sqlite3':
+        specifier: ^7.6.0
+        version: 7.6.13
       better-sqlite3:
         specifier: ^11.0.0
         version: 11.10.0
@@ -39,9 +42,6 @@ importers:
         specifier: ^2.4.0
         version: 2.8.2
     devDependencies:
-      '@types/better-sqlite3':
-        specifier: ^7.6.0
-        version: 7.6.13
       '@types/node':
         specifier: ^20.10.0
         version: 20.19.33

--- a/scripts/automaton.sh
+++ b/scripts/automaton.sh
@@ -1,8 +1,62 @@
 #!/bin/sh
-# Conway Automaton Installer — thin wrapper
+# Conway Automaton Installer
 # curl -fsSL https://conway.tech/automaton.sh | sh
 set -e
-git clone https://github.com/Conway-Research/automaton.git /opt/automaton
-cd /opt/automaton
-npm install && npm run build
+
+REPO="https://github.com/Conway-Research/automaton.git"
+
+# Determine install directory
+if [ -n "$AUTOMATON_DIR" ]; then
+  INSTALL_DIR="$AUTOMATON_DIR"
+elif [ -w /opt ] || [ "$(id -u)" = "0" ]; then
+  INSTALL_DIR="/opt/automaton"
+else
+  INSTALL_DIR="$HOME/.automaton/runtime"
+fi
+
+# Preflight: Node.js
+if ! command -v node >/dev/null 2>&1; then
+  echo "[ERROR] Node.js is required (>= 20). Install it first." >&2
+  exit 1
+fi
+
+NODE_MAJOR=$(node -e "process.stdout.write(String(process.versions.node.split('.')[0]))")
+if [ "$NODE_MAJOR" -lt 20 ]; then
+  echo "[ERROR] Node.js >= 20 required, found $(node -v)." >&2
+  exit 1
+fi
+
+# Preflight: git
+if ! command -v git >/dev/null 2>&1; then
+  echo "[ERROR] git is required." >&2
+  exit 1
+fi
+
+# Enable pnpm via corepack
+if ! command -v pnpm >/dev/null 2>&1; then
+  echo "[INFO]  Enabling pnpm via corepack..."
+  corepack enable pnpm || {
+    echo "[ERROR] Failed to enable pnpm. Install it manually: npm i -g pnpm" >&2
+    exit 1
+  }
+fi
+
+# Clone or update
+if [ -d "$INSTALL_DIR/.git" ]; then
+  echo "[INFO]  Updating existing installation at $INSTALL_DIR..."
+  cd "$INSTALL_DIR" && git pull --ff-only
+else
+  echo "[INFO]  Cloning automaton to $INSTALL_DIR..."
+  mkdir -p "$(dirname "$INSTALL_DIR")"
+  git clone "$REPO" "$INSTALL_DIR"
+  cd "$INSTALL_DIR"
+fi
+
+# Install and build
+echo "[INFO]  Installing dependencies..."
+pnpm install --frozen-lockfile
+echo "[INFO]  Building..."
+pnpm run build
+
+# Launch
 exec node dist/index.js --run

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -15,5 +15,6 @@
     "declarationMap": true,
     "sourceMap": true
   },
-  "include": ["src/**/*"]
+  "include": ["src/**/*"],
+  "exclude": ["src/__tests__"]
 }


### PR DESCRIPTION
- automaton.sh: add adaptive install directory (sandbox /opt vs user home), preflight checks (Node >= 20, git, pnpm), corepack enablement, and idempotent clone-or-update logic. Fixes #45, #47.
- tsconfig.json: exclude src/__tests__ from tsc build so test-only imports (vitest) don't break production compilation.
- package.json: move @types/better-sqlite3 to dependencies since 20+ source files use import type from it and tsc needs the declarations to build.