### PR TITLE
fix(policy): exclude sandbox tools from local path traversal check

### DIFF
--- a/src/agent/policy-rules/path-protection.ts
+++ b/src/agent/policy-rules/path-protection.ts
@@ -118,7 +118,11 @@ function createReadSensitiveRule(): PolicyRule {
 
 /**
  * Deny paths containing traversal sequences after resolution.
- * Applies to: write_file, read_file, edit_own_file
+ *
+ * Only applies to edit_own_file, which modifies local agent source code.
+ * write_file and read_file operate on the remote Conway sandbox via API,
+ * so local cwd-based traversal checks are not meaningful for them and
+ * will false-positive on every absolute sandbox path (e.g. /home/conway/app.py).
  */
 function createTraversalDetectionRule(): PolicyRule {
   return {
@@ -127,7 +131,7 @@ function createTraversalDetectionRule(): PolicyRule {
     priority: 200,
     appliesTo: {
       by: "name",
-      names: ["write_file", "read_file", "edit_own_file"],
+      names: ["edit_own_file"],
     },
     evaluate(request: PolicyRequest): PolicyRuleResult | null {
       const filePath = (request.args.path as string | undefined);


### PR DESCRIPTION
## Summary
- `write_file` and `read_file` operate on the remote Conway sandbox via API, not the local filesystem
- The `path.traversal_detection` policy rule checks if paths resolve within `process.cwd()`, which false-positives on every absolute sandbox path (e.g. `/home/conway/app.py`)
- This blocks **all** remote file writes, forcing agents to fall back to `exec` with shell writes as a workaround
- Fix: restrict traversal detection to `edit_own_file` only, which actually modifies local agent source code

## Impact
This bug causes agents to enter infinite read loops — they try `write_file`, get denied by policy, and fall back to reconnaissance. Agents appear "stuck" or "unable to build" when the real issue is the policy engine blocking valid remote writes.

## Test plan
- [x] Updated `path-protection.test.ts` — all traversal tests now target `edit_own_file`
- [x] Added test verifying `write_file` and `read_file` are excluded from traversal rule
- [x] 25/26 tests pass (1 pre-existing failure in `isProtectedFile` for `/etc/systemd/` path)
- [x] Build passes with zero errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)