### PR TITLE
fix(tools): read_file exec fallback for broken files/read API

### DIFF
--- a/src/conway/client.ts
+++ b/src/conway/client.ts
@@ -177,6 +177,8 @@ export function createConwayClient(
       const result = await request(
         "GET",
         `/v1/sandboxes/${sandboxId}/files/read?path=${encodeURIComponent(filePath)}`,
+        undefined,
+        { retries404: 0 },
       );
       return typeof result === "string" ? result : result.content || "";
     } catch (err: any) {


### PR DESCRIPTION
## Summary
- Conway's `files/read` API is broken for some sandboxes, returning errors on valid file paths
- Adds `exec(cat)` fallback in the `read_file` tool so file reads work via the exec endpoint when the API fails
- Sets `retries404: 0` for `readFile` in `client.ts` since the exec fallback makes 404 retries redundant for file reads

## Context
Depends on #155 (404 retry logic) for the `retries404` parameter.

The `files/read` API failure was observed consistently on sandbox `c6009be125c8dde252b991e6f33c38da`. The exec endpoint works reliably, making it a good fallback.

## Test plan
- [x] Verified fallback works in production — agent successfully reads files via exec when API fails
- [ ] Existing test suite passes (`npx vitest run`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)