### PR TITLE
fix: escape JSON.stringify in installed tool executor (CWE-78)

### DIFF
--- a/src/agent/tools.ts
+++ b/src/agent/tools.ts
@@ -2380,7 +2380,7 @@ function createInstalledToolExecutor(
     const command = tool.config?.command as string | undefined;
     if (command) {
       const result = await ctx.conway.exec(
-        `${command} ${JSON.stringify(args)}`,
+        `${command} ${escapeShellArg(JSON.stringify(args))}`,
         30000,
       );
       return `exit_code: ${result.exitCode}\nstdout: ${result.stdout}\nstderr: ${result.stderr}`;
@@ -2517,4 +2517,9 @@ export async function executeTool(
       error: err.message || String(err),
     };
   }
+}
+
+/** Escape a string for safe shell interpolation. */
+function escapeShellArg(arg: string): string {
+  return `'${arg.replace(/'/g, "'\\''")}'`;
 }


### PR DESCRIPTION
## Summary

Fixes **critical CWE-78 command injection** in `createInstalledToolExecutor()` where `JSON.stringify(args)` output was concatenated directly into a shell command.

### Changes

- Add `escapeShellArg()` helper to `src/agent/tools.ts`
- Wrap `JSON.stringify(args)` with `escapeShellArg()` in the installed tool executor

### Security Impact

**Before:** Tool arguments containing shell metacharacters (backticks, `$()`, etc.) would be interpreted by the shell:
```typescript
args = { input: "`whoami`" }
// Produces: command {"input":"`whoami`"}
// Shell executes backtick content
```

**After:** Arguments are properly escaped, preventing shell interpretation.

Closes #174
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/conway-research/automaton/pull/169" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
