### PR TITLE
fix: add escapeShellArg to read_file, pull_upstream, and npm install commands (CWE-78)

### DIFF
--- a/src/__tests__/tools-security.test.ts
+++ b/src/__tests__/tools-security.test.ts
@@ -545,7 +545,7 @@ describe("package install inline validation", () => {
     const tool = tools.find((t) => t.name === "install_npm_package")!;
     await tool.execute({ package: "axios" }, ctx);
     expect(conway.execCalls.length).toBe(1);
-    expect(conway.execCalls[0].command).toBe("npm install -g axios");
+    expect(conway.execCalls[0].command).toBe("npm install -g 'axios'");
   });
 
   it("install_npm_package allows scoped packages", async () => {

--- a/src/self-mod/tools-manager.ts
+++ b/src/self-mod/tools-manager.ts
@@ -12,6 +12,11 @@ import type {
 import { logModification } from "./audit-log.js";
 import { ulid } from "ulid";
 
+/** Escape a string for safe shell interpolation. */
+function escapeShellArg(arg: string): string {
+  return `'${arg.replace(/'/g, "'\\''")}'`;
+}
+
 /**
  * Install an npm package globally in the sandbox.
  */
@@ -29,7 +34,7 @@ export async function installNpmPackage(
   }
 
   const result = await conway.exec(
-    `npm install -g ${packageName}`,
+    `npm install -g ${escapeShellArg(packageName)}`,
     120000,
   );
 


### PR DESCRIPTION
## Summary

Defense-in-depth: wrap user-controlled parameters with `escapeShellArg()` at execution time in addition to existing policy-layer validation. Prevents command injection if policy rules are bypassed or misconfigured.

### Changes

**`src/agent/tools.ts`:**
- `read_file`: Escape `filePath` in `cat` shell fallback (line 174)
- `pull_upstream`: Add runtime commit hash validation (`/^[a-f0-9]{7,40}$/`) + escape with `escapeShellArg()` + use `--` separator in `git cherry-pick` (lines 526-530)
- `install_npm_package`: Escape `pkg` in `npm install -g` (line 447)
- `install_mcp_server`: Escape `pkg` in `npm install -g` (line 850)

**`src/self-mod/tools-manager.ts`:**
- Add local `escapeShellArg()` utility function
- `installNpmPackage`: Escape `packageName` in `npm install -g` (line 37)

### Security Impact

All 5 locations previously interpolated parameters directly into shell commands. While policy-layer validation (regex, `validate.git_hash`, `validate.package_name`) provides first-line defense, these parameters were unescaped at execution time. A policy bypass or misconfiguration would immediately expose command injection.

Closes #179, closes #180, closes #181