### PR TITLE
fix(registry): correct ABI mismatch and add enumeration fallback for discover_agents

### DIFF
--- a/src/__tests__/discovery-abi.test.ts
+++ b/src/__tests__/discovery-abi.test.ts
@@ -1,0 +1,268 @@
+/**
+ * Discovery ABI & Enumeration Tests
+ *
+ * Tests that:
+ * 1. IDENTITY_ABI uses tokenURI (not agentURI)
+ * 2. queryAgent calls tokenURI and handles ownerOf revert gracefully
+ * 3. getTotalAgents returns 0 when totalSupply reverts
+ * 4. getRegisteredAgentsByEvents scans Transfer events as fallback
+ * 5. discoverAgents uses event fallback when totalSupply returns 0
+ * 6. discoverAgents uses sequential iteration when totalSupply works
+ */
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+// Mock viem before importing erc8004
+const mockReadContract = vi.fn();
+const mockGetBlockNumber = vi.fn();
+const mockGetLogs = vi.fn();
+
+vi.mock("viem", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("viem")>();
+  return {
+    ...actual,
+    createPublicClient: vi.fn(() => ({
+      readContract: mockReadContract,
+      getBlockNumber: mockGetBlockNumber,
+      getLogs: mockGetLogs,
+    })),
+    createWalletClient: vi.fn(() => ({
+      writeContract: vi.fn(),
+    })),
+  };
+});
+
+// Mock logger to suppress output
+vi.mock("../observability/logger.js", () => ({
+  createLogger: () => ({
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    debug: vi.fn(),
+  }),
+}));
+
+import {
+  queryAgent,
+  getTotalAgents,
+  getRegisteredAgentsByEvents,
+} from "../registry/erc8004.js";
+import { discoverAgents } from "../registry/discovery.js";
+
+// ─── ABI Verification ───────────────────────────────────────────
+
+describe("IDENTITY_ABI correctness", () => {
+  it("uses tokenURI not agentURI in the ABI", async () => {
+    // Verify by calling queryAgent — it should call readContract with functionName: "tokenURI"
+    mockReadContract.mockImplementation(async (params: any) => {
+      if (params.functionName === "tokenURI") return "https://example.com/agent.json";
+      if (params.functionName === "ownerOf") return "0x1234567890abcdef1234567890abcdef12345678";
+      throw new Error(`Unexpected function: ${params.functionName}`);
+    });
+
+    const agent = await queryAgent("1");
+    expect(agent).not.toBeNull();
+    expect(agent!.agentURI).toBe("https://example.com/agent.json");
+
+    // Verify tokenURI was called (not agentURI)
+    const tokenURICall = mockReadContract.mock.calls.find(
+      (call: any) => call[0]?.functionName === "tokenURI",
+    );
+    expect(tokenURICall).toBeDefined();
+
+    // Verify agentURI was NOT called
+    const agentURICall = mockReadContract.mock.calls.find(
+      (call: any) => call[0]?.functionName === "agentURI",
+    );
+    expect(agentURICall).toBeUndefined();
+  });
+});
+
+// ─── queryAgent Tests ───────────────────────────────────────────
+
+describe("queryAgent", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("returns agent with URI and owner when both succeed", async () => {
+    mockReadContract.mockImplementation(async (params: any) => {
+      if (params.functionName === "tokenURI") return "https://example.com/card.json";
+      if (params.functionName === "ownerOf") return "0xOwnerAddress";
+      throw new Error(`Unexpected: ${params.functionName}`);
+    });
+
+    const agent = await queryAgent("42");
+    expect(agent).toEqual({
+      agentId: "42",
+      owner: "0xOwnerAddress",
+      agentURI: "https://example.com/card.json",
+    });
+  });
+
+  it("returns agent with empty owner when ownerOf reverts", async () => {
+    mockReadContract.mockImplementation(async (params: any) => {
+      if (params.functionName === "tokenURI") return "https://example.com/card.json";
+      if (params.functionName === "ownerOf") throw new Error("execution reverted");
+      throw new Error(`Unexpected: ${params.functionName}`);
+    });
+
+    const agent = await queryAgent("42");
+    expect(agent).not.toBeNull();
+    expect(agent!.agentId).toBe("42");
+    expect(agent!.agentURI).toBe("https://example.com/card.json");
+    expect(agent!.owner).toBe("");
+  });
+
+  it("returns null when tokenURI reverts", async () => {
+    mockReadContract.mockImplementation(async () => {
+      throw new Error("execution reverted");
+    });
+
+    const agent = await queryAgent("999");
+    expect(agent).toBeNull();
+  });
+});
+
+// ─── getTotalAgents Tests ───────────────────────────────────────
+
+describe("getTotalAgents", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("returns count when totalSupply succeeds", async () => {
+    mockReadContract.mockResolvedValue(BigInt(100));
+    const total = await getTotalAgents();
+    expect(total).toBe(100);
+  });
+
+  it("returns 0 when totalSupply reverts", async () => {
+    mockReadContract.mockRejectedValue(new Error("execution reverted"));
+    const total = await getTotalAgents();
+    expect(total).toBe(0);
+  });
+});
+
+// ─── getRegisteredAgentsByEvents Tests ──────────────────────────
+
+describe("getRegisteredAgentsByEvents", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("returns agents from Transfer events", async () => {
+    mockGetBlockNumber.mockResolvedValue(1_000_000n);
+    mockGetLogs.mockResolvedValue([
+      {
+        args: {
+          from: "0x0000000000000000000000000000000000000000",
+          to: "0xOwner1",
+          tokenId: 18788n,
+        },
+      },
+      {
+        args: {
+          from: "0x0000000000000000000000000000000000000000",
+          to: "0xOwner2",
+          tokenId: 18791n,
+        },
+      },
+    ]);
+
+    const agents = await getRegisteredAgentsByEvents();
+    // Most recent first (reversed)
+    expect(agents).toHaveLength(2);
+    expect(agents[0]).toEqual({ tokenId: "18791", owner: "0xOwner2" });
+    expect(agents[1]).toEqual({ tokenId: "18788", owner: "0xOwner1" });
+  });
+
+  it("respects limit parameter", async () => {
+    mockGetBlockNumber.mockResolvedValue(1_000_000n);
+    mockGetLogs.mockResolvedValue([
+      { args: { from: "0x0000000000000000000000000000000000000000", to: "0xA", tokenId: 1n } },
+      { args: { from: "0x0000000000000000000000000000000000000000", to: "0xB", tokenId: 2n } },
+      { args: { from: "0x0000000000000000000000000000000000000000", to: "0xC", tokenId: 3n } },
+    ]);
+
+    const agents = await getRegisteredAgentsByEvents("mainnet", 2);
+    expect(agents).toHaveLength(2);
+  });
+
+  it("returns empty array when event scan fails", async () => {
+    mockGetBlockNumber.mockRejectedValue(new Error("RPC error"));
+
+    const agents = await getRegisteredAgentsByEvents();
+    expect(agents).toEqual([]);
+  });
+});
+
+// ─── discoverAgents Integration Tests ───────────────────────────
+
+describe("discoverAgents", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("uses sequential iteration when totalSupply returns > 0", async () => {
+    // First call: totalSupply returns 3
+    // Subsequent calls: tokenURI and ownerOf for each agent
+    let callCount = 0;
+    mockReadContract.mockImplementation(async (params: any) => {
+      if (params.functionName === "totalSupply") return BigInt(3);
+      if (params.functionName === "tokenURI") return `https://example.com/agent${callCount++}.json`;
+      if (params.functionName === "ownerOf") return "0xOwner";
+      throw new Error(`Unexpected: ${params.functionName}`);
+    });
+
+    const agents = await discoverAgents(10);
+    // Should have found agents via sequential iteration (3, 2, 1)
+    expect(agents.length).toBeGreaterThan(0);
+    // totalSupply should have been called
+    const totalSupplyCall = mockReadContract.mock.calls.find(
+      (call: any) => call[0]?.functionName === "totalSupply",
+    );
+    expect(totalSupplyCall).toBeDefined();
+    // getLogs should NOT have been called (no event fallback needed)
+    expect(mockGetLogs).not.toHaveBeenCalled();
+  });
+
+  it("falls back to event scanning when totalSupply returns 0", async () => {
+    // totalSupply reverts → getTotalAgents returns 0
+    // Then event scanning kicks in
+    mockReadContract.mockImplementation(async (params: any) => {
+      if (params.functionName === "totalSupply") throw new Error("execution reverted");
+      if (params.functionName === "tokenURI") return "https://example.com/agent.json";
+      if (params.functionName === "ownerOf") throw new Error("execution reverted");
+      throw new Error(`Unexpected: ${params.functionName}`);
+    });
+
+    mockGetBlockNumber.mockResolvedValue(1_000_000n);
+    mockGetLogs.mockResolvedValue([
+      {
+        args: {
+          from: "0x0000000000000000000000000000000000000000",
+          to: "0xEventOwner",
+          tokenId: 18788n,
+        },
+      },
+    ]);
+
+    const agents = await discoverAgents(10);
+    expect(agents).toHaveLength(1);
+    expect(agents[0].agentId).toBe("18788");
+    // Owner comes from event when ownerOf reverts and queryAgent returns empty owner
+    expect(agents[0].owner).toBe("0xEventOwner");
+    expect(agents[0].agentURI).toBe("https://example.com/agent.json");
+    // getLogs should have been called (event fallback)
+    expect(mockGetLogs).toHaveBeenCalled();
+  });
+
+  it("returns empty when both totalSupply and events fail", async () => {
+    mockReadContract.mockRejectedValue(new Error("execution reverted"));
+    mockGetBlockNumber.mockRejectedValue(new Error("RPC error"));
+
+    const agents = await discoverAgents(10);
+    expect(agents).toEqual([]);
+  });
+});


### PR DESCRIPTION
## Problem

`discover_agents` returns "No agents found" for ALL agents on the Conway platform. No agent can discover any other agent. The entire agent economy discovery layer is non-functional.

## Evidence

Verified on-chain against Identity contract `0x8004A169FB4a3325136EB29fA0ceB6D2e539a432` (Base mainnet):
- `tokenURI(18788)` returns valid URI ✅
- `agentURI(18788)` reverts ❌ (function does not exist on contract)
- `totalSupply()` reverts ❌ (ERC-721 Enumerable not implemented)
- `ownerOf(18788)` reverts ❌
- `balanceOf(wallet)` returns correct count ✅
- Registration TXs confirmed successful with Transfer events ✅

## Root Cause

Two bugs in `src/registry/erc8004.ts`:

1. **ABI mismatch:** `IDENTITY_ABI` declares `agentURI(uint256)` but the deployed contract implements standard ERC-721 `tokenURI(uint256)`. The `queryAgent` function calls `agentURI` which reverts.

2. **Broken enumeration:** `getTotalAgents()` calls `totalSupply()` which reverts because the contract doesn't implement ERC-721 Enumerable. The `catch` block silently returns 0. `discoverAgents()` uses this as its loop bound — the loop never executes.

Additionally, `ownerOf(uint256)` reverts on this contract, causing `queryAgent` to fail even when called with a valid token ID.

## Fix

1. **ABI correction:** Replaced `agentURI` with `tokenURI` in `IDENTITY_ABI` and `queryAgent` call site. Internal TypeScript property names (`RegistryEntry.agentURI`) unchanged.

2. **Enumeration fallback:** When `totalSupply()` reverts (returns 0), fall back to Transfer event log scanning. Scan for mint events (`Transfer(address(0), to, tokenId)`) to discover registered agent token IDs and owners. `totalSupply` is tried first for backward compatibility with contracts that implement it.

3. **`ownerOf` resilience:** `queryAgent` now catches `ownerOf` reverts gracefully — agents are still returned with URI data when owner lookup fails. When using event-based discovery, owner is extracted from the Transfer event directly (bypassing `ownerOf`).

## Impact

- Agents can now discover other registered agents on contracts without ERC-721 Enumerable
- `tokenURI` resolves correctly for registered agents
- `ownerOf` failures no longer crash discovery
- Backward compatible: contracts implementing `totalSupply` still work via try-first path
- Registration flow completely untouched
- Zero changes to policy engine, financial rules, or tool behavior

## Testing

- 990 existing tests pass (zero regressions)
- Added: `tokenURI` ABI verification test
- Added: `queryAgent` returns agent when `tokenURI` succeeds
- Added: `queryAgent` handles `ownerOf` revert gracefully
- Added: Event-based fallback when `totalSupply` reverts
- Added: `discoverAgents` end-to-end with event fallback
- Added: Backward compatibility test with working `totalSupply`
- Total: 1002 tests passing across 27 test files
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/conway-research/automaton/pull/187" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
