### PR TITLE
fix: replace require() with ESM import in discovery cache

### DIFF
--- a/src/registry/discovery.ts
+++ b/src/registry/discovery.ts
@@ -15,6 +15,7 @@ import type {
 } from "../types.js";
 import { DEFAULT_DISCOVERY_CONFIG } from "../types.js";
 import { queryAgent, getTotalAgents, getRegisteredAgentsByEvents } from "./erc8004.js";
+import { keccak256, toBytes } from "viem";
 import { createLogger } from "../observability/logger.js";
 const logger = createLogger("registry.discovery");
 
@@ -158,7 +159,6 @@ function setCachedCard(
     const now = new Date().toISOString();
     const validUntil = new Date(Date.now() + ttlMs).toISOString();
     const cardJson = JSON.stringify(card);
-    const { keccak256, toBytes } = require("viem");
     const cardHash = keccak256(toBytes(cardJson));
 
     db.prepare(


### PR DESCRIPTION
## Summary
- `setCachedCard()` in `src/registry/discovery.ts` used `require("viem")` to get `keccak256` and `toBytes`
- Since the project uses `"type": "module"`, `require()` is not defined at runtime and this crashes when the discovery cache tries to store an agent card
- Moved the import to the existing top-level ESM imports where other `viem` utilities are already imported

## Test plan
- [x] `npx tsc --noEmit` passes
- [ ] Verify discovery cache works at runtime (call `discoverAgents()` with a database)

🤖 Generated with [Claude Code](https://claude.com/claude-code)