### PR TITLE
fix: encode calldata in preflight gas estimation

### DIFF
--- a/src/registry/erc8004.ts
+++ b/src/registry/erc8004.ts
@@ -18,6 +18,7 @@ import {
   parseAbi,
   keccak256,
   toBytes,
+  encodeFunctionData,
   type Address,
   type PrivateKeyAccount,
 } from "viem";
@@ -98,12 +99,19 @@ async function preflight(
     transport: http(),
   });
 
+  // Encode calldata for accurate gas estimation
+  const data = encodeFunctionData({
+    abi: functionData.abi,
+    functionName: functionData.functionName,
+    args: functionData.args,
+  });
+
   // Estimate gas
   const gasEstimate = await publicClient
     .estimateGas({
       account: account.address,
       to: functionData.address,
-      data: undefined, // Will be encoded by the client
+      data,
     })
     .catch(() => BigInt(200_000)); // Fallback estimate
 


### PR DESCRIPTION
## Summary
- `preflight()` in `src/registry/erc8004.ts` passes `data: undefined` to `estimateGas()`
- This estimates gas for a plain ETH transfer (~21,000 gas) instead of the actual contract call (register, setAgentURI, etc.)
- The estimation always fails for contract targets, silently falling to the `catch()` fallback of 200,000 gas
- The balance check then uses this placeholder value, providing no real protection against insufficient gas
- Fix: use `encodeFunctionData()` from viem to encode the actual calldata before gas estimation

## Test plan
- [x] `npx tsc --noEmit` passes
- [ ] Verify preflight correctly rejects when balance is too low for the actual contract call

🤖 Generated with [Claude Code](https://claude.com/claude-code)