### PR TITLE
fix: use numeric status code for 403 detection in Conway client

### DIFF
--- a/src/conway/client.ts
+++ b/src/conway/client.ts
@@ -126,7 +126,7 @@ export function createConwayClient(options: ConwayClientOptions): ConwayClient {
       // SECURITY: Never silently fall back to local execution on auth failure.
       // A 403 indicates a credentials mismatch — falling back to local exec
       // would bypass the sandbox security boundary entirely.
-      if (err?.message?.includes("403")) {
+      if (err?.status === 403) {
         throw new Error(
           `Conway API authentication failed (403). Sandbox exec refused. ` +
             `This may indicate a misconfigured or revoked API key. ` +
@@ -162,7 +162,7 @@ export function createConwayClient(options: ConwayClientOptions): ConwayClient {
       });
     } catch (err: any) {
       // SECURITY: Never silently fall back to local FS on auth failure.
-      if (err?.message?.includes("403")) {
+      if (err?.status === 403) {
         throw new Error(
           `Conway API authentication failed (403). File write refused. ` +
             `File will NOT be written locally for security reasons.`,
@@ -186,7 +186,7 @@ export function createConwayClient(options: ConwayClientOptions): ConwayClient {
       return typeof result === "string" ? result : result.content || "";
     } catch (err: any) {
       // SECURITY: Never silently fall back to local FS on auth failure.
-      if (err?.message?.includes("403")) {
+      if (err?.status === 403) {
         throw new Error(
           `Conway API authentication failed (403). File read refused. ` +
             `File will NOT be read locally for security reasons.`,


### PR DESCRIPTION
## Summary
- `exec()`, `writeFile()`, and `readFile()` in `src/conway/client.ts` detect 403 auth failures by matching `err?.message?.includes("403")` against the error message string
- This is fragile: any error whose message coincidentally contains "403" (e.g., port 4030 in a URL, or a response body mentioning HTTP 403) would be misclassified as an authentication failure, throwing a misleading auth error instead of the real error
- Since `request()` already sets `err.status` to the numeric HTTP status code (line 69), the fix uses `err?.status === 403` for reliable detection

## Test plan
- [x] `npx tsc --noEmit` passes
- [ ] Verify 403 responses still trigger the auth-failure error path
- [ ] Verify non-403 errors with "403" in message text are not misclassified

🤖 Generated with [Claude Code](https://claude.com/claude-code)