### PR TITLE
fix: replace require() with ESM import in skills loader

### DIFF
--- a/src/skills/loader.ts
+++ b/src/skills/loader.ts
@@ -6,6 +6,7 @@
  * YAML frontmatter + Markdown instructions.
  */
 
+import { execFileSync } from "child_process";
 import fs from "fs";
 import path from "path";
 import type { Skill, AutomatonDatabase } from "../types.js";
@@ -104,7 +105,6 @@ function checkRequirements(skill: Skill): boolean {
         return false;
       }
       try {
-        const { execFileSync } = require("child_process");
         execFileSync("which", [bin], { stdio: "ignore" });
       } catch {
         return false;


### PR DESCRIPTION
## Summary
- `checkRequirements()` in `skills/loader.ts` calls `require("child_process")` inside the function body
- Since the project uses `"type": "module"`, `require()` is not available at runtime and throws `ReferenceError`
- The error is silently caught by the `try/catch` on line 78, causing every skill with a `requires.bins` field to be skipped — binary requirement checks never actually run

## Fix
- Move `execFileSync` to a top-level ESM `import` statement (consistent with how `skills/registry.ts` already imports it)
- Remove the inline `require()` call

## Test plan
- [ ] Verify `npx tsc --noEmit` passes (confirmed locally)
- [ ] Create a skill with `requires.bins: ["node"]` and verify it loads correctly
- [ ] Create a skill with `requires.bins: ["nonexistent_binary"]` and verify it is skipped