### PR TITLE
fix(discovery): replace require() with ESM import for viem in cache writer

### DIFF
--- a/src/registry/discovery.ts
+++ b/src/registry/discovery.ts
@@ -15,6 +15,7 @@ import type {
 } from "../types.js";
 import { DEFAULT_DISCOVERY_CONFIG } from "../types.js";
 import { queryAgent, getTotalAgents, getRegisteredAgentsByEvents } from "./erc8004.js";
+import { keccak256, toBytes } from "viem";
 import { createLogger } from "../observability/logger.js";
 const logger = createLogger("registry.discovery");
 
@@ -158,7 +159,6 @@ function setCachedCard(
     const now = new Date().toISOString();
     const validUntil = new Date(Date.now() + ttlMs).toISOString();
     const cardJson = JSON.stringify(card);
-    const { keccak256, toBytes } = require("viem");
     const cardHash = keccak256(toBytes(cardJson));
 
     db.prepare(


### PR DESCRIPTION
### Problem

Agent discovery cache writes silently fail on every call. The `discovered_agents_cache` SQLite table is never populated, forcing agents to perform full on-chain Transfer event scans (2081+ events, ~6 seconds) on every `discover_agents` call. Logs show 20+ `require is not defined` errors per discovery call (one per agent card enrichment).

### Root Cause

`setCachedCard` in `src/registry/discovery.ts` uses `require("viem")` to import `keccak256` and `toBytes` for computing agent card hashes. The project is ESM (`"type": "module"` in package.json, all imports use `.js` extensions), so `require()` is not available. The error is caught by the surrounding try-catch and silently swallowed, making the failure invisible except in verbose logs.

### Fix

Replace `require("viem")` with a standard ESM import. The `keccak256` and `toBytes` functions are imported at the top of the file, consistent with how other modules in the codebase import from `viem`.

### Impact

- Discovery cache writes succeed — `discovered_agents_cache` table populates correctly
- Subsequent discovery calls can use cached agent cards instead of re-fetching from the network
- Eliminates 20+ `ReferenceError` stack traces per discovery call from logs
- Zero behavioral change for agents — discovery results are identical, just cached for performance
- No new dependencies — `viem` is already a project dependency

### Testing

- `pnpm build` — zero errors (import resolves correctly)
- `pnpm test` — all 1005 existing tests pass (27 test files)

### Note: Related Issue (Not Fixed Here)

During investigation, we observed that agents using `data:` URIs for inline ERC-8004 agent cards are blocked by SSRF protection (`isAllowedUri` only allows `https:` and `ipfs:`). `data:` URIs don't make network requests and pose no SSRF risk, but they're a legitimate pattern for inline agent metadata. Happy to open a separate issue or PR if the team wants to support `data:` URIs for agent cards.