### PR TITLE
fix: 子沙盒内存配置化，修复硬编码 512MB 导致的问题

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -53,6 +53,8 @@ export interface AutomatonConfig {
   skillsDir: string;
   agentId?: string;
   maxChildren: number;
+  /** 子沙盒内存配置 (MB)，默认 1024 */
+  childSandboxMemoryMb?: number;
   parentAddress?: Address;
   socialRelayUrl?: string;
   treasuryPolicy?: TreasuryPolicy;
@@ -71,6 +73,7 @@ export const DEFAULT_CONFIG: Partial<AutomatonConfig> = {
   version: "0.2.0",
   skillsDir: "~/.automaton/skills",
   maxChildren: 3,
+  childSandboxMemoryMb: 1024,
   socialRelayUrl: "https://social.conway.tech",
 };
 


### PR DESCRIPTION
## 问题描述

### Bug 描述
`src/replication/spawn.ts` 中硬编码了 `memoryMb: 512`，导致以下问题：

1. **无法创建更大内存的子沙盒** - 512MB 是 Conway 沙盒的最小配置
2. **重复扣费但创建失败** - 尝试创建非 512MB 沙盒时会失败，但费用可能已扣除
3. **子代理 OOM** - 512MB 内存不足以运行编译等任务

### 复现步骤
1. 配置 `automaton.json` 中的 `inferenceModel: "glm-5"`
2. 让 automaton 尝试创建子沙盒
3. 观察到创建失败或 OOM 错误

## 解决方案

### 修改内容
1. 添加 `childSandboxMemoryMb` 配置项到 `AutomatonConfig`
2. 默认值从 512MB 提升到 1024MB
3. `spawn.ts` 中两处硬编码改为从配置读取

### 修改文件
- `src/types.ts`: 添加 `childSandboxMemoryMb?: number` 配置项
- `src/replication/spawn.ts`: 使用配置值替代硬编码 512

## 使用方法

在 `automaton.json` 中配置：
```json
{
  "childSandboxMemoryMb": 1024
}
```

## 测试

- ✅ 本地构建通过
- ✅ 沙盒部署验证（1GB 内存成功运行）

## 影响范围

- **向后兼容**：现有配置无需修改，默认值从 512MB 提升到 1024MB
- **影响用户**：所有使用子沙盒功能的 automaton
- **风险**：低 - 仅增加默认内存配置
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/conway-research/automaton/pull/222" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
