### PR TITLE
fix(discovery): binary search fallback when totalSupply() reverts

### DIFF
--- a/src/registry/erc8004.ts
+++ b/src/registry/erc8004.ts
@@ -503,14 +503,15 @@ async function estimateTotalByBinarySearch(
   };
 
   // Quick probe to find an upper bound
-  let upper = 1024;
+  // Quick probe to find an upper bound
+  let upper = 1;
   while (await exists(upper)) {
     upper *= 2;
     if (upper > 10_000_000) break; // safety cap
   }
 
-  // Binary search between upper/2 and upper
-  let lo = Math.floor(upper / 2);
+  // Binary search between 0 and upper
+  let lo = 0;
   let hi = upper;
   while (lo < hi) {
     const mid = Math.floor((lo + hi + 1) / 2);


### PR DESCRIPTION
## Summary

- The ERC-8004 proxy contract on Base does not implement ERC-721 Enumerable, so `totalSupply()` reverts
- The existing fallback (Transfer event scanning) is slow and unreliable due to public RPC block-range limits and per-chunk timeouts
- Adds `estimateTotalByBinarySearch()` that probes `ownerOf(tokenId)` to find the highest minted tokenId in ~15 RPC calls (O(log n))
- Once the total is known, the main `discoverAgents()` path iterates by tokenId directly — fast and reliable

Tested against Base mainnet: correctly discovered ~20,900+ registered agents where the previous code found 0.

Complements #228 (paginated event scanning) and #239 (RPC timeout tuning) — this PR provides a faster primary path while those improve the event-scanning fallback.

## Test plan

- [x] `pnpm typecheck` passes
- [x] Manual test: binary search returns ~20,900 on Base mainnet
- [x] Manual test: `discoverAgents()` returns real agent cards (e.g. "MontraFi Agent")
- [ ] CI passes
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/conway-research/automaton/pull/241" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
