### PR TITLE
feat: add configurable RPC endpoint for on-chain interactions

### DIFF
--- a/src/agent/tools.ts
+++ b/src/agent/tools.ts
@@ -1389,6 +1389,7 @@ Model: ${ctx.inference.getDefaultModel()}
             args.agent_uri as string,
             ((args.network as string) || "mainnet") as any,
             ctx.db,
+            ctx.config.rpcUrl,
           );
           return `Registered on-chain! Agent ID: ${entry.agentId}, TX: ${entry.txHash}`;
         } catch (err: any) {
@@ -1435,9 +1436,10 @@ Model: ${ctx.inference.getDefaultModel()}
         const limit = (args.limit as number) || 10;
 
         // Phase 3.2: Pass db.raw for agent card caching
+        const rpcUrl = ctx.config.rpcUrl;
         const agents = keyword
-          ? await searchAgents(keyword, limit, network, undefined, ctx.db.raw)
-          : await discoverAgents(limit, network, undefined, ctx.db.raw);
+          ? await searchAgents(keyword, limit, network, undefined, ctx.db.raw, rpcUrl)
+          : await discoverAgents(limit, network, undefined, ctx.db.raw, rpcUrl);
 
         if (agents.length === 0) return "No agents found.";
         return agents
@@ -1494,6 +1496,7 @@ Model: ${ctx.inference.getDefaultModel()}
           comment,
           network,
           ctx.db,
+          ctx.config.rpcUrl,
         );
         return `Feedback submitted. TX: ${hash}`;
       },

--- a/src/conway/x402.ts
+++ b/src/conway/x402.ts
@@ -213,9 +213,10 @@ export async function getUsdcBalanceDetailed(
   }
 
   try {
+    const rpcUrl = process.env.AUTOMATON_RPC_URL || undefined;
     const client = createPublicClient({
       chain,
-      transport: http(undefined, { timeout: 10_000 }),
+      transport: http(rpcUrl, { timeout: 10_000 }),
     });
 
     const balance = await client.readContract({

--- a/src/registry/discovery.ts
+++ b/src/registry/discovery.ts
@@ -218,9 +218,10 @@ export async function discoverAgents(
   network: Network = "mainnet",
   config?: Partial<DiscoveryConfig>,
   db?: import("better-sqlite3").Database,
+  rpcUrl?: string,
 ): Promise<DiscoveredAgent[]> {
   const cfg = { ...DEFAULT_DISCOVERY_CONFIG, ...config };
-  const total = await getTotalAgents(network);
+  const total = await getTotalAgents(network, rpcUrl);
   const agents: DiscoveredAgent[] = [];
 
   const overallStart = Date.now();
@@ -235,7 +236,7 @@ export async function discoverAgents(
       }
 
       try {
-        const agent = await queryAgent(i.toString(), network);
+        const agent = await queryAgent(i.toString(), network, rpcUrl);
         if (agent) {
           await enrichAgentWithCard(agent, cfg, db);
           agents.push(agent);
@@ -247,7 +248,7 @@ export async function discoverAgents(
   } else {
     // totalSupply returned 0 (likely reverted) — fall back to Transfer event scanning
     logger.info("totalSupply returned 0, falling back to Transfer event scanning");
-    const eventAgents = await getRegisteredAgentsByEvents(network, Math.min(limit, cfg.maxScanCount));
+    const eventAgents = await getRegisteredAgentsByEvents(network, Math.min(limit, cfg.maxScanCount), rpcUrl);
 
     for (const { tokenId, owner } of eventAgents) {
       if (Date.now() - overallStart > DISCOVERY_TIMEOUT_MS) {
@@ -257,7 +258,7 @@ export async function discoverAgents(
 
       try {
         // Try queryAgent first (gets tokenURI), fall back to event data only
-        const agent = await queryAgent(tokenId, network);
+        const agent = await queryAgent(tokenId, network, rpcUrl);
         if (agent) {
           // Use owner from event if queryAgent couldn't get it
           if (!agent.owner && owner) {
@@ -347,8 +348,9 @@ export async function searchAgents(
   network: Network = "mainnet",
   config?: Partial<DiscoveryConfig>,
   db?: import("better-sqlite3").Database,
+  rpcUrl?: string,
 ): Promise<DiscoveredAgent[]> {
-  const all = await discoverAgents(50, network, config, db);
+  const all = await discoverAgents(50, network, config, db, rpcUrl);
   const lower = keyword.toLowerCase();
 
   return all

--- a/src/setup/configure.ts
+++ b/src/setup/configure.ts
@@ -303,6 +303,7 @@ async function configureGeneral(config: AutomatonConfig): Promise<void> {
   );
   config.maxChildren = await askNumber("Max child automatons", config.maxChildren);
   config.socialRelayUrl = (await askString("Social relay URL", config.socialRelayUrl)) || undefined;
+  config.rpcUrl = (await askString("RPC endpoint  (Base chain, e.g. https://mainnet.base.org)", config.rpcUrl)) || undefined;
 
   console.log("");
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -62,6 +62,8 @@ export interface AutomatonConfig {
   // Phase 2 config additions
   soulConfig?: SoulConfig;
   modelStrategy?: ModelStrategyConfig;
+  /** Custom RPC endpoint for Base chain interactions (overrides default public RPC) */
+  rpcUrl?: string;
 }
 
 export const DEFAULT_CONFIG: Partial<AutomatonConfig> = {


### PR DESCRIPTION
## Summary

Fixes #240

Adds a configurable RPC endpoint for all Base chain interactions, allowing users to use their own RPC provider instead of relying on the default public RPC.

- Adds `rpcUrl?: string` to `AutomatonConfig` in `src/types.ts`
- Adds `AUTOMATON_RPC_URL` environment variable as fallback
- Updates all `createPublicClient` / `createWalletClient` calls in `src/registry/erc8004.ts` (6 functions: `preflight`, `registerAgent`, `updateAgentURI`, `leaveFeedback`, `queryAgent`, `getTotalAgents`, `getRegisteredAgentsByEvents`, `hasRegisteredAgent`)
- Updates `src/conway/x402.ts` to use env var for USDC balance checks
- Threads `rpcUrl` through `src/registry/discovery.ts` (`discoverAgents`, `searchAgents`)
- Passes `ctx.config.rpcUrl` from agent tools in `src/agent/tools.ts`
- Adds RPC endpoint to interactive setup in `src/setup/configure.ts`

**Resolution priority**: explicit `rpcUrl` param > `AUTOMATON_RPC_URL` env var > viem default (public RPC)

## Test plan

- [x] `pnpm typecheck` passes
- [x] `discovery-abi.test.ts` (12 tests) passes
- [x] `social.test.ts` (52 tests, includes `leaveFeedback` validation) passes
- [ ] Manual: set `AUTOMATON_RPC_URL` and verify RPC calls use it
- [ ] Manual: set `rpcUrl` in `automaton.json` and verify it overrides env var
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/conway-research/automaton/pull/250" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
