### PR TITLE
feat: add 0xWork marketplace integration for agent revenue

### DIFF
--- a/src/__tests__/oxwork.test.ts
+++ b/src/__tests__/oxwork.test.ts
@@ -1,0 +1,331 @@
+/**
+ * Tests for the 0xWork API client — conway/oxwork module.
+ *
+ * Covers: browseOpenTasks, getTaskDetail, oxworkAuth, claimTask,
+ * submitWork, getMyTasks.
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import {
+  browseOpenTasks,
+  getTaskDetail,
+  oxworkAuth,
+  claimTask,
+  submitWork,
+  getMyTasks,
+} from "../conway/oxwork.js";
+
+// ─── Mock fetch ────────────────────────────────────────────────
+
+const originalFetch = globalThis.fetch;
+
+function mockResponse(
+  status: number,
+  body: unknown = {},
+  headers: Record<string, string> = {},
+): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    statusText: status === 200 ? "OK" : "Error",
+    headers: new Headers({
+      "content-type": "application/json",
+      ...headers,
+    }),
+  });
+}
+
+beforeEach(() => {
+  globalThis.fetch = vi.fn();
+});
+
+afterEach(() => {
+  globalThis.fetch = originalFetch;
+  vi.restoreAllMocks();
+});
+
+// ─── Mock data ─────────────────────────────────────────────────
+
+const mockTask = {
+  id: 137,
+  chain_task_id: 28,
+  poster_address: "0x84631A26Fab1525449063c7Dce50019c6CeeDc9C",
+  worker_address: null,
+  description: "Write a 500+ word article about AI agents",
+  category: "Writing",
+  bounty_amount: "20.0",
+  deadline: Math.floor(Date.now() / 1000) + 86400 * 7,
+  status: "Open",
+  delivery_link: null,
+  delivery_description: null,
+  created_at: new Date().toISOString(),
+};
+
+const mockClaimedTask = {
+  ...mockTask,
+  id: 200,
+  chain_task_id: 45,
+  worker_address: "0x1234567890abcdef1234567890abcdef12345678",
+  status: "Claimed",
+};
+
+const mockCompletedTask = {
+  ...mockTask,
+  id: 201,
+  chain_task_id: 46,
+  worker_address: "0x1234567890abcdef1234567890abcdef12345678",
+  status: "Completed",
+  delivery_link: "https://example.com/delivery",
+  delivery_description: "Article delivered as requested",
+};
+
+const mockAuth = {
+  address: "0x1234567890abcdef1234567890abcdef12345678",
+  signature: "0xsigned",
+  nonce: "nonce-123",
+};
+
+// ─── Tests ─────────────────────────────────────────────────────
+
+describe("browseOpenTasks", () => {
+  it("returns open tasks with no filters", async () => {
+    const tasks = [mockTask, { ...mockTask, id: 138, category: "Development" }];
+
+    (globalThis.fetch as ReturnType<typeof vi.fn>).mockResolvedValueOnce(
+      mockResponse(200, tasks),
+    );
+
+    const result = await browseOpenTasks();
+
+    expect(result).toEqual(tasks);
+    expect(globalThis.fetch).toHaveBeenCalledOnce();
+    const callUrl = (globalThis.fetch as ReturnType<typeof vi.fn>).mock.calls[0][0] as string;
+    expect(callUrl).toContain("/tasks?");
+    expect(callUrl).toContain("status=open");
+  });
+
+  it("filters by category", async () => {
+    const tasks = [mockTask];
+
+    (globalThis.fetch as ReturnType<typeof vi.fn>).mockResolvedValueOnce(
+      mockResponse(200, tasks),
+    );
+
+    const result = await browseOpenTasks({ category: "Writing" });
+
+    expect(result).toEqual(tasks);
+    const callUrl = (globalThis.fetch as ReturnType<typeof vi.fn>).mock.calls[0][0] as string;
+    expect(callUrl).toContain("category=Writing");
+  });
+
+  it("filters by bounty range", async () => {
+    const tasks = [mockTask];
+
+    (globalThis.fetch as ReturnType<typeof vi.fn>).mockResolvedValueOnce(
+      mockResponse(200, tasks),
+    );
+
+    const result = await browseOpenTasks({ minBounty: 10, maxBounty: 50 });
+
+    expect(result).toEqual(tasks);
+    const callUrl = (globalThis.fetch as ReturnType<typeof vi.fn>).mock.calls[0][0] as string;
+    expect(callUrl).toContain("min_bounty=10");
+    expect(callUrl).toContain("max_bounty=50");
+  });
+
+  it("handles empty results", async () => {
+    (globalThis.fetch as ReturnType<typeof vi.fn>).mockResolvedValueOnce(
+      mockResponse(200, []),
+    );
+
+    const result = await browseOpenTasks();
+
+    expect(result).toEqual([]);
+  });
+
+  it("handles API errors gracefully", async () => {
+    (globalThis.fetch as ReturnType<typeof vi.fn>).mockResolvedValueOnce(
+      mockResponse(500, { error: "Internal server error" }),
+    );
+
+    await expect(browseOpenTasks()).rejects.toThrow("Failed to browse tasks: HTTP 500");
+  });
+});
+
+describe("getTaskDetail", () => {
+  it("returns full task detail", async () => {
+    (globalThis.fetch as ReturnType<typeof vi.fn>).mockResolvedValueOnce(
+      mockResponse(200, mockTask),
+    );
+
+    const result = await getTaskDetail(137);
+
+    expect(result).toEqual(mockTask);
+    const callUrl = (globalThis.fetch as ReturnType<typeof vi.fn>).mock.calls[0][0] as string;
+    expect(callUrl).toContain("/tasks/137");
+  });
+
+  it("handles non-existent task (404)", async () => {
+    (globalThis.fetch as ReturnType<typeof vi.fn>).mockResolvedValueOnce(
+      mockResponse(404, { error: "Task not found" }),
+    );
+
+    await expect(getTaskDetail(99999)).rejects.toThrow("Failed to get task 99999: HTTP 404");
+  });
+});
+
+describe("oxworkAuth", () => {
+  it("gets nonce and signs it with account", async () => {
+    const mockNonce = "abc123-nonce-value";
+
+    // Nonce endpoint
+    (globalThis.fetch as ReturnType<typeof vi.fn>).mockResolvedValueOnce(
+      mockResponse(200, { nonce: mockNonce }),
+    );
+
+    const mockAccount = {
+      address: "0x1234567890abcdef1234567890abcdef12345678" as const,
+      signMessage: vi.fn().mockResolvedValue("0xsigned-message-hex"),
+    } as unknown as import("viem").PrivateKeyAccount;
+
+    const result = await oxworkAuth(mockAccount);
+
+    expect(result.address).toBe(mockAccount.address);
+    expect(result.nonce).toBe(mockNonce);
+    expect(result.signature).toBe("0xsigned-message-hex");
+    expect(mockAccount.signMessage).toHaveBeenCalledWith({ message: mockNonce });
+
+    const callUrl = (globalThis.fetch as ReturnType<typeof vi.fn>).mock.calls[0][0] as string;
+    expect(callUrl).toContain("/auth/nonce");
+    expect(callUrl).toContain(mockAccount.address);
+  });
+
+  it("throws on nonce fetch failure", async () => {
+    (globalThis.fetch as ReturnType<typeof vi.fn>).mockResolvedValueOnce(
+      mockResponse(500, { error: "Server error" }),
+    );
+
+    const mockAccount = {
+      address: "0xabcdef1234567890abcdef1234567890abcdef12" as const,
+      signMessage: vi.fn(),
+    } as unknown as import("viem").PrivateKeyAccount;
+
+    await expect(oxworkAuth(mockAccount)).rejects.toThrow("Failed to fetch nonce: HTTP 500");
+    expect(mockAccount.signMessage).not.toHaveBeenCalled();
+  });
+});
+
+describe("claimTask", () => {
+  it("successfully claims a task", async () => {
+    (globalThis.fetch as ReturnType<typeof vi.fn>).mockResolvedValueOnce(
+      mockResponse(200, mockClaimedTask),
+    );
+
+    const result = await claimTask(137, mockAuth);
+
+    expect(result.status).toBe("Claimed");
+    expect(result.worker_address).toBe(mockAuth.address);
+
+    const [url, options] = (globalThis.fetch as ReturnType<typeof vi.fn>).mock.calls[0];
+    expect(url).toContain("/tasks/137/claim");
+    expect(options.method).toBe("POST");
+    expect(options.headers["X-Address"]).toBe(mockAuth.address);
+    expect(options.headers["X-Nonce"]).toBe(mockAuth.nonce);
+    expect(options.headers["X-Signature"]).toBe(mockAuth.signature);
+  });
+
+  it("handles already-claimed task error", async () => {
+    (globalThis.fetch as ReturnType<typeof vi.fn>).mockResolvedValueOnce(
+      mockResponse(409, { error: "Task already claimed by another worker" }),
+    );
+
+    await expect(claimTask(137, mockAuth)).rejects.toThrow("Failed to claim task 137: HTTP 409");
+  });
+
+  it("rejects with invalid auth (401)", async () => {
+    (globalThis.fetch as ReturnType<typeof vi.fn>).mockResolvedValueOnce(
+      mockResponse(401, { error: "Invalid or expired authentication" }),
+    );
+
+    const badAuth = { address: "", signature: "", nonce: "" };
+
+    await expect(claimTask(137, badAuth)).rejects.toThrow("Failed to claim task 137: HTTP 401");
+  });
+});
+
+describe("submitWork", () => {
+  it("successfully submits work", async () => {
+    (globalThis.fetch as ReturnType<typeof vi.fn>).mockResolvedValueOnce(
+      mockResponse(200, mockCompletedTask),
+    );
+
+    const result = await submitWork(
+      137,
+      "https://example.com/delivery",
+      "Article delivered as requested",
+      mockAuth,
+    );
+
+    expect(result.status).toBe("Completed");
+    expect(result.delivery_link).toBe("https://example.com/delivery");
+    expect(result.delivery_description).toBe("Article delivered as requested");
+
+    const [url, options] = (globalThis.fetch as ReturnType<typeof vi.fn>).mock.calls[0];
+    expect(url).toContain("/tasks/137/submit");
+    expect(options.method).toBe("POST");
+    const body = JSON.parse(options.body as string);
+    expect(body.delivery_link).toBe("https://example.com/delivery");
+    expect(body.delivery_description).toBe("Article delivered as requested");
+  });
+
+  it("handles validation errors", async () => {
+    (globalThis.fetch as ReturnType<typeof vi.fn>).mockResolvedValueOnce(
+      mockResponse(422, {
+        error: "Validation failed",
+        details: { delivery_link: "Must be a valid URL" },
+      }),
+    );
+
+    await expect(
+      submitWork(137, "not-a-url", "", mockAuth),
+    ).rejects.toThrow("Failed to submit work for task 137: HTTP 422");
+  });
+});
+
+describe("getMyTasks", () => {
+  it("returns all worker tasks", async () => {
+    const tasks = [mockClaimedTask, mockCompletedTask];
+
+    (globalThis.fetch as ReturnType<typeof vi.fn>).mockResolvedValueOnce(
+      mockResponse(200, tasks),
+    );
+
+    const result = await getMyTasks("0x1234567890abcdef1234567890abcdef12345678");
+
+    expect(result).toHaveLength(2);
+    expect(result[0].status).toBe("Claimed");
+    expect(result[1].status).toBe("Completed");
+
+    const callUrl = (globalThis.fetch as ReturnType<typeof vi.fn>).mock.calls[0][0] as string;
+    expect(callUrl).toContain("/tasks/worker/0x1234");
+  });
+
+  it("returns empty array when no tasks", async () => {
+    (globalThis.fetch as ReturnType<typeof vi.fn>).mockResolvedValueOnce(
+      mockResponse(200, []),
+    );
+
+    const result = await getMyTasks("0xnew");
+
+    expect(result).toEqual([]);
+  });
+
+  it("handles server errors", async () => {
+    (globalThis.fetch as ReturnType<typeof vi.fn>).mockResolvedValueOnce(
+      mockResponse(500, { error: "Internal server error" }),
+    );
+
+    await expect(
+      getMyTasks("0xbad"),
+    ).rejects.toThrow("Failed to get tasks for 0xbad: HTTP 500");
+  });
+});

--- a/src/agent/tools.ts
+++ b/src/agent/tools.ts
@@ -55,6 +55,8 @@ const EXTERNAL_SOURCE_TOOLS = new Set([
   "exec",
   "web_fetch",
   "check_social_inbox",
+  "oxwork_browse",
+  "oxwork_status",
 ]);
 
 // ─── Self-Preservation Guard ───────────────────────────────────
@@ -2934,19 +2936,31 @@ Model: ${ctx.inference.getDefaultModel()}
           return "0xWork requires an EVM wallet for authentication. Solana agents cannot use this tool.";
         }
 
-        const { oxworkAuth, submitWork } = await import("../conway/oxwork.js");
+        const { oxworkAuth, submitWork, getTaskDetail } = await import("../conway/oxwork.js");
         const taskId = args.task_id as number;
         const link = args.delivery_link as string;
         const desc = args.delivery_description as string;
 
+        // Verify the agent owns this claim before submitting
+        const task = await getTaskDetail(taskId);
+        if (task.worker_address?.toLowerCase() !== ctx.identity.account.address.toLowerCase()) {
+          return `Task #${taskId} is not claimed by you (claimed by: ${task.worker_address ?? "no one"}). Cannot submit.`;
+        }
+        if (task.status !== "Claimed") {
+          return `Task #${taskId} status is "${task.status}" — expected "Claimed". Cannot submit.`;
+        }
+
         const auth = await oxworkAuth(ctx.identity.account);
         const submitted = await submitWork(taskId, link, desc, auth);
 
+        // Record as tool_use, NOT service_revenue — bounty isn't released
+        // until the poster approves. Revenue should only be recorded when
+        // the agent detects approval via oxwork_status.
         ctx.db.insertTransaction({
           id: ulid(),
-          type: "service_revenue",
-          amountCents: Math.round(parseFloat(submitted.bounty_amount) * 100),
-          description: `Submitted work for 0xWork task #${taskId} ($${submitted.bounty_amount} bounty, pending approval)`,
+          type: "tool_use",
+          amountCents: 0,
+          description: `Submitted work for 0xWork task #${taskId} ($${submitted.bounty_amount} bounty, pending poster approval)`,
           timestamp: new Date().toISOString(),
         });
 

--- a/src/agent/tools.ts
+++ b/src/agent/tools.ts
@@ -2796,6 +2796,198 @@ Model: ${ctx.inference.getDefaultModel()}
       },
     },
 
+    // === 0xWork Revenue Tools ===
+    {
+      name: "oxwork_browse",
+      description:
+        "Browse open tasks on the 0xWork marketplace (https://0xwork.org). " +
+        "Returns paid tasks with USDC bounties that the agent can claim and complete to earn revenue. " +
+        "Categories: Social, Writing, Code, Data, Research, Creative. " +
+        "Requires EVM wallet — Solana agents cannot use this tool.",
+      category: "financial" as ToolCategory,
+      riskLevel: "safe" as RiskLevel,
+      parameters: {
+        type: "object",
+        properties: {
+          category: {
+            type: "string",
+            description:
+              "Filter by category: Social, Writing, Code, Data, Research, Creative",
+          },
+          min_bounty: {
+            type: "number",
+            description: "Minimum bounty in USD (e.g. 10)",
+          },
+          max_bounty: {
+            type: "number",
+            description: "Maximum bounty in USD (e.g. 100)",
+          },
+        },
+      },
+      execute: async (args, ctx) => {
+        const chainType = ctx.config.chainType ?? ctx.identity.chainType ?? "evm";
+        if (chainType !== "evm") {
+          return "0xWork requires an EVM wallet for authentication. Solana agents cannot use this tool.";
+        }
+
+        const { browseOpenTasks } = await import("../conway/oxwork.js");
+        const tasks = await browseOpenTasks({
+          category: args.category as string | undefined,
+          minBounty: args.min_bounty as number | undefined,
+          maxBounty: args.max_bounty as number | undefined,
+        });
+
+        if (tasks.length === 0) return "No open tasks found matching your filters.";
+
+        const lines = tasks.slice(0, 20).map(
+          (t) =>
+            `#${t.id} [${t.category}] $${t.bounty_amount} — ${t.description.slice(0, 120)}${t.description.length > 120 ? "…" : ""}`,
+        );
+        return `Found ${tasks.length} open task(s):\n\n${lines.join("\n")}`;
+      },
+    },
+    {
+      name: "oxwork_claim",
+      description:
+        "Claim an open task on 0xWork to begin working on it. " +
+        "After claiming, you must complete the work before the deadline and submit it. " +
+        "Note: may require AXOBOTL token stake depending on the task. " +
+        "Requires EVM wallet.",
+      category: "financial" as ToolCategory,
+      riskLevel: "dangerous" as RiskLevel,
+      parameters: {
+        type: "object",
+        properties: {
+          task_id: {
+            type: "number",
+            description: "The 0xWork task ID to claim",
+          },
+        },
+        required: ["task_id"],
+      },
+      execute: async (args, ctx) => {
+        const chainType = ctx.config.chainType ?? ctx.identity.chainType ?? "evm";
+        if (chainType !== "evm") {
+          return "0xWork requires an EVM wallet for authentication. Solana agents cannot use this tool.";
+        }
+
+        const { oxworkAuth, claimTask, getTaskDetail } = await import(
+          "../conway/oxwork.js"
+        );
+        const taskId = args.task_id as number;
+
+        const task = await getTaskDetail(taskId);
+        if (task.status !== "Open") {
+          return `Task #${taskId} is not open (status: ${task.status}). Cannot claim.`;
+        }
+
+        const auth = await oxworkAuth(ctx.identity.account);
+        const claimed = await claimTask(taskId, auth);
+
+        ctx.db.insertTransaction({
+          id: ulid(),
+          type: "tool_use",
+          amountCents: 0,
+          description: `Claimed 0xWork task #${taskId} ($${task.bounty_amount} bounty, category: ${task.category})`,
+          timestamp: new Date().toISOString(),
+        });
+
+        return (
+          `Successfully claimed task #${claimed.id}!\n` +
+          `Category: ${claimed.category}\n` +
+          `Bounty: $${claimed.bounty_amount} USDC\n` +
+          `Deadline: ${new Date(claimed.deadline * 1000).toISOString()}\n` +
+          `Description: ${claimed.description}`
+        );
+      },
+    },
+    {
+      name: "oxwork_submit",
+      description:
+        "Submit completed work for a claimed 0xWork task. " +
+        "Provide a delivery link (URL to your work) and a description of what was delivered. " +
+        "USDC bounty is released to your wallet on poster approval. " +
+        "Requires EVM wallet.",
+      category: "financial" as ToolCategory,
+      riskLevel: "dangerous" as RiskLevel,
+      parameters: {
+        type: "object",
+        properties: {
+          task_id: {
+            type: "number",
+            description: "The 0xWork task ID to submit work for",
+          },
+          delivery_link: {
+            type: "string",
+            description: "URL to the delivered work (e.g. a gist, repo, or hosted page)",
+          },
+          delivery_description: {
+            type: "string",
+            description: "Description of what was delivered",
+          },
+        },
+        required: ["task_id", "delivery_link", "delivery_description"],
+      },
+      execute: async (args, ctx) => {
+        const chainType = ctx.config.chainType ?? ctx.identity.chainType ?? "evm";
+        if (chainType !== "evm") {
+          return "0xWork requires an EVM wallet for authentication. Solana agents cannot use this tool.";
+        }
+
+        const { oxworkAuth, submitWork } = await import("../conway/oxwork.js");
+        const taskId = args.task_id as number;
+        const link = args.delivery_link as string;
+        const desc = args.delivery_description as string;
+
+        const auth = await oxworkAuth(ctx.identity.account);
+        const submitted = await submitWork(taskId, link, desc, auth);
+
+        ctx.db.insertTransaction({
+          id: ulid(),
+          type: "service_revenue",
+          amountCents: Math.round(parseFloat(submitted.bounty_amount) * 100),
+          description: `Submitted work for 0xWork task #${taskId} ($${submitted.bounty_amount} bounty, pending approval)`,
+          timestamp: new Date().toISOString(),
+        });
+
+        return (
+          `Work submitted for task #${submitted.id}!\n` +
+          `Status: ${submitted.status}\n` +
+          `Bounty: $${submitted.bounty_amount} USDC\n` +
+          `The poster will review your submission. USDC is released on approval.`
+        );
+      },
+    },
+    {
+      name: "oxwork_status",
+      description:
+        "Check the status of your claimed and submitted tasks on 0xWork. " +
+        "Requires EVM wallet.",
+      category: "financial" as ToolCategory,
+      riskLevel: "safe" as RiskLevel,
+      parameters: {
+        type: "object",
+        properties: {},
+      },
+      execute: async (_args, ctx) => {
+        const chainType = ctx.config.chainType ?? ctx.identity.chainType ?? "evm";
+        if (chainType !== "evm") {
+          return "0xWork requires an EVM wallet for authentication. Solana agents cannot use this tool.";
+        }
+
+        const { getMyTasks } = await import("../conway/oxwork.js");
+        const tasks = await getMyTasks(ctx.identity.account.address);
+
+        if (tasks.length === 0) return "You have no active tasks on 0xWork.";
+
+        const lines = tasks.map(
+          (t) =>
+            `#${t.id} [${t.status}] $${t.bounty_amount} — ${t.description.slice(0, 100)}${t.description.length > 100 ? "…" : ""}`,
+        );
+        return `Your 0xWork tasks (${tasks.length}):\n\n${lines.join("\n")}`;
+      },
+    },
+
     // === Orchestration Tools ===
     {
       name: "create_goal",

--- a/src/conway/oxwork.ts
+++ b/src/conway/oxwork.ts
@@ -1,0 +1,163 @@
+/**
+ * 0xWork API Client
+ *
+ * HTTP client for the 0xWork decentralized task marketplace.
+ * Allows browsing open tasks, claiming work, and submitting deliverables.
+ * Revenue flows back to the agent's wallet via on-chain escrow release on approval.
+ *
+ * Note: Authentication uses EIP-191 personal_sign, so this module
+ * requires an EVM wallet. Solana agents cannot use 0xWork directly.
+ */
+
+import type { PrivateKeyAccount } from "viem";
+import { createLogger } from "../observability/logger.js";
+
+const logger = createLogger("oxwork");
+
+const OXWORK_API_BASE = "https://api.0xwork.org";
+
+// ─── Types ───────────────────────────────────────────────────────
+
+export interface OxworkTask {
+  id: number;
+  chain_task_id: number;
+  poster_address: string;
+  worker_address: string | null;
+  description: string;
+  category: string;
+  bounty_amount: string;
+  deadline: number;
+  status: string;
+  delivery_link: string | null;
+  delivery_description: string | null;
+  created_at: string;
+}
+
+export interface OxworkAuth {
+  address: string;
+  nonce: string;
+  signature: string;
+}
+
+interface BrowseFilters {
+  category?: string;
+  minBounty?: number;
+  maxBounty?: number;
+}
+
+// ─── Auth ────────────────────────────────────────────────────────
+
+/**
+ * Authenticate with the 0xWork API using wallet signature.
+ * Fetches a nonce, signs it with EIP-191 personal_sign, and returns auth credentials.
+ */
+export async function oxworkAuth(account: PrivateKeyAccount): Promise<OxworkAuth> {
+  const nonceResp = await fetch(`${OXWORK_API_BASE}/auth/nonce?address=${account.address}`);
+  if (!nonceResp.ok) {
+    throw new Error(`Failed to fetch nonce: HTTP ${nonceResp.status}`);
+  }
+  const { nonce } = (await nonceResp.json()) as { nonce: string };
+
+  const signature = await account.signMessage({ message: nonce });
+
+  logger.info(`Authenticated with 0xWork as ${account.address}`);
+
+  return {
+    address: account.address,
+    nonce,
+    signature,
+  };
+}
+
+// ─── Task Browsing ───────────────────────────────────────────────
+
+/**
+ * Browse open tasks on 0xWork with optional filters.
+ */
+export async function browseOpenTasks(filters?: BrowseFilters): Promise<OxworkTask[]> {
+  const params = new URLSearchParams({ status: "open" });
+  if (filters?.category) params.set("category", filters.category);
+  if (filters?.minBounty != null) params.set("min_bounty", String(filters.minBounty));
+  if (filters?.maxBounty != null) params.set("max_bounty", String(filters.maxBounty));
+
+  const resp = await fetch(`${OXWORK_API_BASE}/tasks?${params}`);
+  if (!resp.ok) {
+    throw new Error(`Failed to browse tasks: HTTP ${resp.status}`);
+  }
+  return (await resp.json()) as OxworkTask[];
+}
+
+/**
+ * Get full details for a specific task.
+ */
+export async function getTaskDetail(taskId: number): Promise<OxworkTask> {
+  const resp = await fetch(`${OXWORK_API_BASE}/tasks/${taskId}`);
+  if (!resp.ok) {
+    throw new Error(`Failed to get task ${taskId}: HTTP ${resp.status}`);
+  }
+  return (await resp.json()) as OxworkTask;
+}
+
+// ─── Task Actions ────────────────────────────────────────────────
+
+/**
+ * Claim an open task for the authenticated worker.
+ */
+export async function claimTask(taskId: number, auth: OxworkAuth): Promise<OxworkTask> {
+  const resp = await fetch(`${OXWORK_API_BASE}/tasks/${taskId}/claim`, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      "X-Address": auth.address,
+      "X-Nonce": auth.nonce,
+      "X-Signature": auth.signature,
+    },
+  });
+  if (!resp.ok) {
+    const body = await resp.text();
+    throw new Error(`Failed to claim task ${taskId}: HTTP ${resp.status} — ${body}`);
+  }
+  return (await resp.json()) as OxworkTask;
+}
+
+/**
+ * Submit completed work for a claimed task.
+ */
+export async function submitWork(
+  taskId: number,
+  deliveryLink: string,
+  deliveryDescription: string,
+  auth: OxworkAuth,
+): Promise<OxworkTask> {
+  const resp = await fetch(`${OXWORK_API_BASE}/tasks/${taskId}/submit`, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      "X-Address": auth.address,
+      "X-Nonce": auth.nonce,
+      "X-Signature": auth.signature,
+    },
+    body: JSON.stringify({
+      delivery_link: deliveryLink,
+      delivery_description: deliveryDescription,
+    }),
+  });
+  if (!resp.ok) {
+    const body = await resp.text();
+    throw new Error(`Failed to submit work for task ${taskId}: HTTP ${resp.status} — ${body}`);
+  }
+  return (await resp.json()) as OxworkTask;
+}
+
+// ─── Worker Tasks ────────────────────────────────────────────────
+
+/**
+ * Get all tasks assigned to a specific worker address.
+ */
+export async function getMyTasks(address: string): Promise<OxworkTask[]> {
+  const resp = await fetch(`${OXWORK_API_BASE}/tasks/worker/${address}`);
+  if (!resp.ok) {
+    throw new Error(`Failed to get tasks for ${address}: HTTP ${resp.status}`);
+  }
+  return (await resp.json()) as OxworkTask[];
+}

--- a/src/conway/oxwork.ts
+++ b/src/conway/oxwork.ts
@@ -15,6 +15,7 @@ import { createLogger } from "../observability/logger.js";
 const logger = createLogger("oxwork");
 
 const OXWORK_API_BASE = "https://api.0xwork.org";
+const OXWORK_TIMEOUT_MS = 15_000;
 
 // ─── Types ───────────────────────────────────────────────────────
 
@@ -52,7 +53,10 @@ interface BrowseFilters {
  * Fetches a nonce, signs it with EIP-191 personal_sign, and returns auth credentials.
  */
 export async function oxworkAuth(account: PrivateKeyAccount): Promise<OxworkAuth> {
-  const nonceResp = await fetch(`${OXWORK_API_BASE}/auth/nonce?address=${account.address}`);
+  const nonceResp = await fetch(
+    `${OXWORK_API_BASE}/auth/nonce?address=${encodeURIComponent(account.address)}`,
+    { signal: AbortSignal.timeout(OXWORK_TIMEOUT_MS) },
+  );
   if (!nonceResp.ok) {
     throw new Error(`Failed to fetch nonce: HTTP ${nonceResp.status}`);
   }
@@ -60,7 +64,7 @@ export async function oxworkAuth(account: PrivateKeyAccount): Promise<OxworkAuth
 
   const signature = await account.signMessage({ message: nonce });
 
-  logger.info(`Authenticated with 0xWork as ${account.address}`);
+  logger.debug("Authenticated with 0xWork", { address: account.address.slice(0, 10) + "…" });
 
   return {
     address: account.address,
@@ -80,7 +84,9 @@ export async function browseOpenTasks(filters?: BrowseFilters): Promise<OxworkTa
   if (filters?.minBounty != null) params.set("min_bounty", String(filters.minBounty));
   if (filters?.maxBounty != null) params.set("max_bounty", String(filters.maxBounty));
 
-  const resp = await fetch(`${OXWORK_API_BASE}/tasks?${params}`);
+  const resp = await fetch(`${OXWORK_API_BASE}/tasks?${params}`, {
+    signal: AbortSignal.timeout(OXWORK_TIMEOUT_MS),
+  });
   if (!resp.ok) {
     throw new Error(`Failed to browse tasks: HTTP ${resp.status}`);
   }
@@ -91,7 +97,9 @@ export async function browseOpenTasks(filters?: BrowseFilters): Promise<OxworkTa
  * Get full details for a specific task.
  */
 export async function getTaskDetail(taskId: number): Promise<OxworkTask> {
-  const resp = await fetch(`${OXWORK_API_BASE}/tasks/${taskId}`);
+  const resp = await fetch(`${OXWORK_API_BASE}/tasks/${encodeURIComponent(taskId)}`, {
+    signal: AbortSignal.timeout(OXWORK_TIMEOUT_MS),
+  });
   if (!resp.ok) {
     throw new Error(`Failed to get task ${taskId}: HTTP ${resp.status}`);
   }
@@ -104,8 +112,9 @@ export async function getTaskDetail(taskId: number): Promise<OxworkTask> {
  * Claim an open task for the authenticated worker.
  */
 export async function claimTask(taskId: number, auth: OxworkAuth): Promise<OxworkTask> {
-  const resp = await fetch(`${OXWORK_API_BASE}/tasks/${taskId}/claim`, {
+  const resp = await fetch(`${OXWORK_API_BASE}/tasks/${encodeURIComponent(taskId)}/claim`, {
     method: "POST",
+    signal: AbortSignal.timeout(OXWORK_TIMEOUT_MS),
     headers: {
       "Content-Type": "application/json",
       "X-Address": auth.address,
@@ -129,8 +138,9 @@ export async function submitWork(
   deliveryDescription: string,
   auth: OxworkAuth,
 ): Promise<OxworkTask> {
-  const resp = await fetch(`${OXWORK_API_BASE}/tasks/${taskId}/submit`, {
+  const resp = await fetch(`${OXWORK_API_BASE}/tasks/${encodeURIComponent(taskId)}/submit`, {
     method: "POST",
+    signal: AbortSignal.timeout(OXWORK_TIMEOUT_MS),
     headers: {
       "Content-Type": "application/json",
       "X-Address": auth.address,
@@ -155,7 +165,9 @@ export async function submitWork(
  * Get all tasks assigned to a specific worker address.
  */
 export async function getMyTasks(address: string): Promise<OxworkTask[]> {
-  const resp = await fetch(`${OXWORK_API_BASE}/tasks/worker/${address}`);
+  const resp = await fetch(`${OXWORK_API_BASE}/tasks/worker/${encodeURIComponent(address)}`, {
+    signal: AbortSignal.timeout(OXWORK_TIMEOUT_MS),
+  });
   if (!resp.ok) {
     throw new Error(`Failed to get tasks for ${address}: HTTP ${resp.status}`);
   }

--- a/src/heartbeat/tasks.ts
+++ b/src/heartbeat/tasks.ts
@@ -41,6 +41,7 @@ export const COLONY_TASK_INTERVALS_MS = {
   agent_pool_optimize: 1_800_000,
   knowledge_store_prune: 86_400_000,
   dead_agent_cleanup: 3_600_000,
+  scan_oxwork_tasks: 1_800_000, // 30 min — pure HTTP, zero inference cost
 } as const;
 
 export const BUILTIN_TASKS: Record<string, HeartbeatTaskFn> = {
@@ -519,7 +520,7 @@ export const BUILTIN_TASKS: Record<string, HeartbeatTaskFn> = {
         const amount = Math.max(0, Math.floor(tx.amountCents ?? 0));
         if (amount === 0) continue;
 
-        if (tx.type === "transfer_in" || tx.type === "credit_purchase") {
+        if (tx.type === "transfer_in" || tx.type === "credit_purchase" || tx.type === "service_revenue") {
           revenueCents += amount;
           continue;
         }
@@ -701,6 +702,59 @@ export const BUILTIN_TASKS: Record<string, HeartbeatTaskFn> = {
       return { shouldWake: false };
     } catch (error) {
       logger.error("dead_agent_cleanup failed", error instanceof Error ? error : undefined);
+      return { shouldWake: false };
+    }
+  },
+
+  // === 0xWork Task Scanner (zero inference cost — pure HTTP) ===
+  scan_oxwork_tasks: async (_ctx: TickContext, taskCtx: HeartbeatLegacyContext) => {
+    if (!shouldRunAtInterval(taskCtx, "scan_oxwork_tasks", COLONY_TASK_INTERVALS_MS.scan_oxwork_tasks)) {
+      return { shouldWake: false };
+    }
+
+    // 0xWork requires EVM wallet — skip for Solana agents
+    const chainType = taskCtx.config.chainType ?? taskCtx.identity.chainType ?? "evm";
+    if (chainType !== "evm") {
+      return { shouldWake: false };
+    }
+
+    try {
+      const { browseOpenTasks } = await import("../conway/oxwork.js");
+      const tasks = await browseOpenTasks();
+
+      // Filter: only tasks with real bounty and enough time left
+      const now = Math.floor(Date.now() / 1000);
+      const MIN_BOUNTY = 5;
+      const MIN_DEADLINE_HOURS = 24;
+      const viable = tasks.filter(
+        (t) =>
+          parseFloat(t.bounty_amount) >= MIN_BOUNTY
+          && t.deadline > now + MIN_DEADLINE_HOURS * 3600,
+      );
+
+      taskCtx.db.setKV("last_oxwork_scan", JSON.stringify({
+        timestamp: new Date().toISOString(),
+        totalOpen: tasks.length,
+        viable: viable.length,
+      }));
+
+      if (viable.length === 0) return { shouldWake: false };
+
+      // Summarize top opportunities (no inference — just string formatting)
+      const top = viable
+        .sort((a, b) => parseFloat(b.bounty_amount) - parseFloat(a.bounty_amount))
+        .slice(0, 5);
+
+      const summary = top
+        .map((t) => `#${t.id} [${t.category}] $${t.bounty_amount}`)
+        .join(", ");
+
+      return {
+        shouldWake: true,
+        message: `${viable.length} paid task(s) on 0xWork: ${summary}. Use oxwork_browse to review.`,
+      };
+    } catch (error) {
+      logger.error("scan_oxwork_tasks failed", error instanceof Error ? error : undefined);
       return { shouldWake: false };
     }
   },

--- a/src/heartbeat/tasks.ts
+++ b/src/heartbeat/tasks.ts
@@ -718,6 +718,13 @@ export const BUILTIN_TASKS: Record<string, HeartbeatTaskFn> = {
       return { shouldWake: false };
     }
 
+    // Backoff after previous failure to avoid hammering a down API
+    const backoffUntil = taskCtx.db.getKV("oxwork_scan_backoff_until");
+    if (backoffUntil && new Date(backoffUntil) > new Date()) {
+      return { shouldWake: false };
+    }
+    taskCtx.db.deleteKV("oxwork_scan_backoff_until");
+
     try {
       const { browseOpenTasks } = await import("../conway/oxwork.js");
       const tasks = await browseOpenTasks();
@@ -755,6 +762,11 @@ export const BUILTIN_TASKS: Record<string, HeartbeatTaskFn> = {
       };
     } catch (error) {
       logger.error("scan_oxwork_tasks failed", error instanceof Error ? error : undefined);
+      // Back off for one interval on failure
+      taskCtx.db.setKV(
+        "oxwork_scan_backoff_until",
+        new Date(Date.now() + COLONY_TASK_INTERVALS_MS.scan_oxwork_tasks).toISOString(),
+      );
       return { shouldWake: false };
     }
   },

--- a/src/types.ts
+++ b/src/types.ts
@@ -252,7 +252,8 @@ export type TransactionType =
   | "tool_use"
   | "transfer_in"
   | "transfer_out"
-  | "funding_request";
+  | "funding_request"
+  | "service_revenue";
 
 // ─── Self-Modification ───────────────────────────────────────────
 


### PR DESCRIPTION
## Summary

Closes #192 — adds 0xWork as the first revenue source for automatons.

Until now, agents could only **spend** (inference, x402 payments, credit topups). This PR gives them a direct path to **earn** USDC: browse tasks → claim → do work → submit → get paid via on-chain escrow.

### What's new

- **`src/conway/oxwork.ts`** — HTTP client for the 0xWork API (auth via EIP-191 wallet signature, task browsing, claiming, submitting work)
- **4 new agent tools** in `src/agent/tools.ts`:
  - `oxwork_browse` — discover open paid tasks (filter by category/bounty)
  - `oxwork_claim` — claim a task to begin working on it
  - `oxwork_submit` — submit completed work for poster review
  - `oxwork_status` — check status of your claimed/submitted tasks
- **`scan_oxwork_tasks` heartbeat task** — auto-discovers paid tasks every 30 minutes at zero inference cost (pure HTTP)
- **`service_revenue` transaction type** — proper income tracking in the financial ledger (also counted in `colony_financial_report`)
- **Solana wallet guards** — all 4 tools + heartbeat scanner gracefully skip for Solana agents (0xWork uses EIP-191 which requires EVM)
- **`src/__tests__/oxwork.test.ts`** — 17 unit tests with mocked fetch covering all API functions

### Improvements over v1

- Rebased onto latest `main` (includes Solana integration, pretty-logs, etc.)
- Added Solana chain-type guards to all tools and heartbeat scanner
- Added `service_revenue` transaction type so revenue is tracked separately from transfers
- `oxwork_submit` now records the bounty amount as `service_revenue` in the transaction table
- `colony_financial_report` now counts `service_revenue` in revenue totals

### Notes
- Authentication uses EIP-191 personal_sign (nonce from `/auth/nonce`)
- Some tasks require AXOBOTL token stake for claiming — the agent should check requirements before claiming
- No new dependencies added — uses native `fetch()` and existing viem wallet
- Revenue flow: Agent completes work → poster approves → on-chain escrow releases USDC to agent wallet

## Test plan
- [x] `tsc --noEmit` passes (zero type errors)
- [x] 17/17 oxwork tests pass
- [x] tools-security (68 tests), financial (23 tests) pass — no regressions
- [x] heartbeat tests (19 tests) pass
- [ ] Manual: run `oxwork_browse` against live API, verify task listing
- [ ] End-to-end: claim a test task, submit, verify USDC receipt