### PR TITLE
fix(discovery): return full wallet addresses in discover_agents output

### DIFF
--- a/src/agent/tools.ts
+++ b/src/agent/tools.ts
@@ -1443,7 +1443,7 @@ Model: ${ctx.inference.getDefaultModel()}
         return agents
           .map(
             (a) =>
-              `#${a.agentId} ${a.name || "unnamed"} (${a.owner.slice(0, 10)}...): ${a.description || a.agentURI}`,
+              `#${a.agentId} ${a.name || "unnamed"} (${a.owner}): ${a.description || a.agentURI}`,
           )
           .join("\n");
       },


### PR DESCRIPTION
## Problem

`discover_agents` truncates wallet addresses to 10 characters in its output via `.slice(0, 10)`, producing addresses like `0xF3F8Eb20...`. These truncated addresses cannot be used with `send_message` or any other tool requiring a full 42-character Ethereum address (`0x` + 40 hex). The discover-then-communicate pipeline — the most fundamental inter-agent workflow — is broken.

## Root Cause

**File:** `src/agent/tools.ts`, line 1446

```typescript
`#${a.agentId} ${a.name || "unnamed"} (${a.owner.slice(0, 10)}...): ${a.description || a.agentURI}`
```

The `.slice(0, 10)` discards 32 of 42 characters from each wallet address. The social relay rejects truncated addresses with: `Policy denied: VALIDATION_FAILED — Invalid address format. Must be 0x followed by 40 hex characters.`

## Fix Applied

Removed `.slice(0, 10)` and the trailing `...` from the owner address interpolation:

```typescript
`#${a.agentId} ${a.name || "unnamed"} (${a.owner}): ${a.description || a.agentURI}`
```

## Diff

```
1 file changed, 1 insertion(+), 1 deletion(-)
```

- `src/agent/tools.ts`: Line 1446 — removed `.slice(0, 10)` and `...` from owner address in discover_agents output formatter.

## Verification

| Check | Result |
|-------|--------|
| `pnpm build` | Zero errors |
| `pnpm test` (vitest) | All test suites pass, zero failures |
| `git diff main --stat` | 1 file, 1 line changed |
| `check_reputation` line 1522 NOT modified | Confirmed (out of scope) |
| No test assertions on truncated format | Confirmed — no tests assert `slice(0, 10)` or `0x...` in discovery output |

## Impact Assessment

| Metric | Value |
|--------|-------|
| Additional tokens per agent | ~8 (32 chars at ~0.25 tok/char) |
| Additional tokens for 20 agents | ~160 |
| Additional cost per discovery call (Sonnet) | ~$0.0005 |
| Code paths affected | `discoverAgents` and `searchAgents` (shared formatter) |
| Backward compatibility | Yes — output structure unchanged, only address completeness changes |

## Out of Scope (Noted)

- `check_reputation` (line 1522) has the same `.slice(0, 10)` truncation on `fromAgent` addresses. Separate concern, separate PR.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/conway-research/automaton/pull/255" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
