### PR TITLE
feat(discovery): add format parameter for structured JSON output

### DIFF
--- a/src/agent/tools.ts
+++ b/src/agent/tools.ts
@@ -1425,6 +1425,11 @@ Model: ${ctx.inference.getDefaultModel()}
           keyword: { type: "string", description: "Search keyword (optional)" },
           limit: { type: "number", description: "Max results (default: 10)" },
           network: { type: "string", description: "mainnet or testnet" },
+          format: {
+            type: "string",
+            description:
+              'Output format: "text" (default, human-readable) or "json" (structured data)',
+          },
         },
       },
       execute: async (args, ctx) => {
@@ -1440,6 +1445,19 @@ Model: ${ctx.inference.getDefaultModel()}
           : await discoverAgents(limit, network, undefined, ctx.db.raw);
 
         if (agents.length === 0) return "No agents found.";
+
+        if ((args.format as string)?.toLowerCase() === "json") {
+          return JSON.stringify(
+            agents.map((a) => ({
+              agentId: a.agentId,
+              owner: a.owner,
+              agentURI: a.agentURI,
+              name: a.name || null,
+              description: a.description || null,
+            })),
+          );
+        }
+
         return agents
           .map(
             (a) =>


### PR DESCRIPTION
## Problem

`discover_agents` returns human-readable text output only. Agents that need to programmatically process discovery results — building directories, filtering by capability, persisting structured records — must parse unstructured text back into individual fields. The structured data exists upstream in the `DiscoveredAgent` type but is discarded during formatting.

## Solution

Added an optional `format` parameter to the `discover_agents` tool definition.

**File:** `src/agent/tools.ts`

### Change 1: Parameter schema (line ~1428)

Added `format` property to `parameters.properties`:

```typescript
format: {
  type: "string",
  description:
    'Output format: "text" (default, human-readable) or "json" (structured data)',
},
```

### Change 2: JSON output branch (line ~1447)

Added conditional JSON serialization before the existing text formatter:

```typescript
if ((args.format as string)?.toLowerCase() === "json") {
  return JSON.stringify(
    agents.map((a) => ({
      agentId: a.agentId,
      owner: a.owner,
      agentURI: a.agentURI,
      name: a.name || null,
      description: a.description || null,
    })),
  );
}
```

## Design Decisions

- **Default remains text** — zero behavioral change for existing agents
- **Explicit field mapping** — not raw serialization; output contract is stable if `DiscoveredAgent` gains internal fields
- **`null` for missing fields** — clean JSON rather than fallback values like `"unnamed"`
- **Case-insensitive** — `.toLowerCase()` handles `"json"`, `"JSON"`, `"Json"`
- **Both code paths benefit** — `discoverAgents` and `searchAgents` share the same formatter
- **Empty results unchanged** — "No agents found." returned for both formats

## Verification

- `pnpm build` — zero errors
- `npx vitest run src/__tests__/tools-security.test.ts` — 68/68 passed
- `npx vitest run src/__tests__/policy-engine.test.ts` — 26/26 passed
- Diff: 1 file changed, 18 insertions

## Impact

- Backward compatible — default output completely unchanged
- Enables programmatic discovery for agents building registries, trust layers, analytics
- No new dependencies
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/conway-research/automaton/pull/256" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
