### PR TITLE
feat(observability): human-readable terminal output for --run and CLI commands

### DIFF
--- a/packages/cli/src/commands/logs.ts
+++ b/packages/cli/src/commands/logs.ts
@@ -4,8 +4,11 @@
  * View the automaton's turn log.
  */
 
+import chalk from "chalk";
 import { loadConfig, resolvePath } from "@conway/automaton/config.js";
 import { createDatabase } from "@conway/automaton/state/database.js";
+
+const accent = chalk.rgb(131, 127, 255);
 
 const args = process.argv.slice(3);
 let limit = 20;
@@ -16,7 +19,7 @@ if (tailIdx !== -1 && args[tailIdx + 1]) {
 
 const config = loadConfig();
 if (!config) {
-  console.log("No automaton configuration found.");
+  console.log(chalk.red("No automaton configuration found."));
   process.exit(1);
 }
 
@@ -25,27 +28,54 @@ const db = createDatabase(dbPath);
 
 const turns = db.getRecentTurns(limit);
 
+function stateColor(state: string): string {
+  switch (state) {
+    case "normal": return chalk.green(state);
+    case "low_compute": return chalk.yellow(state);
+    case "critical": return chalk.red(state);
+    case "dead": return chalk.gray(state);
+    default: return chalk.white(state);
+  }
+}
+
+const divider = chalk.dim("─".repeat(72));
+
 if (turns.length === 0) {
-  console.log("No turns recorded yet.");
+  console.log(chalk.dim("No turns recorded yet."));
 } else {
+  console.log(accent.bold(`\nShowing last ${turns.length} turn(s)\n`));
   for (const turn of turns) {
-    console.log(`\n--- Turn ${turn.id} [${turn.timestamp}] state:${turn.state} ---`);
+    console.log(divider);
+    console.log(
+      accent.bold(`Turn #${turn.id}`) +
+      chalk.dim(`  ${turn.timestamp}  `) +
+      stateColor(turn.state)
+    );
+
     if (turn.input) {
-      console.log(`Input (${turn.inputSource}): ${turn.input.slice(0, 200)}`);
+      console.log(accent("▸ Input") + chalk.dim(` [${turn.inputSource}]`) + "  " + turn.input.slice(0, 200));
     }
-    console.log(`Thinking: ${turn.thinking.slice(0, 500)}`);
+
+    console.log(chalk.dim("▸ Thinking  ") + chalk.white(turn.thinking.slice(0, 500)));
+
     if (turn.toolCalls.length > 0) {
-      console.log("Tools:");
+      console.log(accent("▸ Tools"));
       for (const tc of turn.toolCalls) {
-        console.log(
-          `  ${tc.name}: ${tc.error ? `ERROR: ${tc.error}` : tc.result.slice(0, 100)}`,
-        );
+        if (tc.error) {
+          console.log("  " + chalk.red(`✗ ${tc.name}`) + "  " + chalk.red(tc.error.slice(0, 100)));
+        } else {
+          console.log("  " + chalk.green(`✓ ${tc.name}`) + "  " + chalk.dim(tc.result.slice(0, 100)));
+        }
       }
     }
+
     console.log(
-      `Tokens: ${turn.tokenUsage.totalTokens} | Cost: $${(turn.costCents / 100).toFixed(4)}`,
+      chalk.yellow(`tokens: ${turn.tokenUsage.totalTokens}`) +
+      chalk.dim("  |  ") +
+      chalk.yellow(`cost: $${(turn.costCents / 100).toFixed(4)}`)
     );
   }
+  console.log(divider);
 }
 
 db.close();

--- a/packages/cli/src/commands/status.ts
+++ b/packages/cli/src/commands/status.ts
@@ -4,12 +4,15 @@
  * Show the current status of an automaton.
  */
 
+import chalk from "chalk";
 import { loadConfig, resolvePath } from "@conway/automaton/config.js";
 import { createDatabase } from "@conway/automaton/state/database.js";
 
+const accent = chalk.rgb(131, 127, 255);
+
 const config = loadConfig();
 if (!config) {
-  console.log("No automaton configuration found.");
+  console.log(chalk.red("No automaton configuration found."));
   process.exit(1);
 }
 
@@ -22,26 +25,41 @@ const tools = db.getInstalledTools();
 const heartbeats = db.getHeartbeatEntries();
 const recentTurns = db.getRecentTurns(5);
 
-console.log(`
-=== ${config.name} ===
-Address:    ${config.walletAddress}
-Creator:    ${config.creatorAddress}
-Sandbox:    ${config.sandboxId}
-State:      ${state}
-Turns:      ${turnCount}
-Tools:      ${tools.length} installed
-Heartbeats: ${heartbeats.filter((h) => h.enabled).length} active
-Model:      ${config.inferenceModel}
-`);
+function stateColor(s: string): string {
+  switch (s) {
+    case "normal": return chalk.green.bold(s);
+    case "low_compute": return chalk.yellow.bold(s);
+    case "critical": return chalk.red.bold(s);
+    case "dead": return chalk.gray.bold(s);
+    default: return chalk.white.bold(s);
+  }
+}
+
+const divider = chalk.dim("─".repeat(52));
+const label = (s: string) => chalk.dim(s.padEnd(12));
+
+console.log("\n" + accent.bold(`  ◈ ${config.name}`) + "\n" + divider);
+console.log(label("Address")  + chalk.white(config.walletAddress));
+console.log(label("Creator")  + chalk.white(config.creatorAddress));
+console.log(label("Sandbox")  + chalk.white(config.sandboxId));
+console.log(label("State")    + stateColor(state));
+console.log(label("Turns")    + chalk.yellow(String(turnCount)));
+console.log(label("Tools")    + chalk.yellow(`${tools.length} installed`));
+console.log(label("Heartbeat") + chalk.yellow(`${heartbeats.filter((h) => h.enabled).length} active`));
+console.log(label("Model")    + chalk.white(config.inferenceModel));
+console.log(divider);
 
 if (recentTurns.length > 0) {
-  console.log("Recent activity:");
+  console.log(chalk.bold("\nRecent activity"));
   for (const turn of recentTurns) {
-    const tools = turn.toolCalls.map((t) => t.name).join(", ");
+    const toolNames = turn.toolCalls.map((t) => t.name).join(", ");
     console.log(
-      `  [${turn.timestamp}] ${turn.thinking.slice(0, 80)}...${tools ? ` (tools: ${tools})` : ""}`,
+      "  " + chalk.dim(turn.timestamp) + "  " +
+      chalk.white(turn.thinking.slice(0, 80)) + chalk.dim("...") +
+      (toolNames ? chalk.magenta(`  [${toolNames}]`) : "")
     );
   }
 }
 
+console.log();
 db.close();

--- a/src/index.ts
+++ b/src/index.ts
@@ -29,7 +29,8 @@ import { SpendTracker } from "./agent/spend-tracker.js";
 import { createDefaultRules } from "./agent/policy-rules/index.js";
 import type { AutomatonIdentity, AgentState, Skill, SocialClientInterface } from "./types.js";
 import { DEFAULT_TREASURY_POLICY } from "./types.js";
-import { createLogger, setGlobalLogLevel } from "./observability/logger.js";
+import { createLogger, setGlobalLogLevel, StructuredLogger } from "./observability/logger.js";
+import { prettySink } from "./observability/pretty-sink.js";
 import { bootstrapTopup } from "./conway/topup.js";
 import { randomUUID } from "crypto";
 import { keccak256, toHex } from "viem";
@@ -118,6 +119,7 @@ Environment:
   }
 
   if (args.includes("--run")) {
+    StructuredLogger.setSink(prettySink);
     await run();
     return;
   }

--- a/src/observability/pretty-sink.ts
+++ b/src/observability/pretty-sink.ts
@@ -1,0 +1,87 @@
+/**
+ * Pretty log sink
+ *
+ * Human-readable terminal output for --run mode.
+ * Replaces raw JSON stdout with colored, structured log lines.
+ * Register via: StructuredLogger.setSink(prettySink)
+ */
+
+import chalk from "chalk";
+import type { LogEntry } from "../types.js";
+
+const accent = chalk.rgb(131, 127, 255);
+
+// Map bracket prefixes in loop messages to styles
+const PREFIX_STYLES: Array<[RegExp, (label: string, rest: string) => string]> = [
+  [/^\[WAKE UP\]/, (l, r) => accent.bold(l) + " " + chalk.white(r)],
+  [/^\[SLEEP\]/, (l, r) => chalk.blue.dim(l) + " " + chalk.dim(r)],
+  [/^\[THINK\]/, (l, r) => accent.dim(l) + " " + chalk.dim(r)],
+  [/^\[THOUGHT\]/, (l, r) => chalk.dim(l) + " " + chalk.white(r)],
+  [/^\[TOOL\]/, (l, r) => chalk.magenta(l) + " " + chalk.white(r)],
+  [/^\[TOOL RESULT\]/, (l, r) => {
+    const isError = r.startsWith("ERROR:") || r.includes(": ERROR:");
+    return (isError ? chalk.red(l) : chalk.green(l)) + " " + (isError ? chalk.red(r) : chalk.dim(r));
+  }],
+  [/^\[CRITICAL\]/, (l, r) => chalk.red.bold(l) + " " + chalk.red(r)],
+  [/^\[FATAL\]/, (l, r) => chalk.red.bold(l) + " " + chalk.red(r)],
+  [/^\[ERROR\]/, (l, r) => chalk.red(l) + " " + chalk.red(r)],
+  [/^\[LOOP\]/, (l, r) => chalk.yellow(l) + " " + chalk.yellow(r)],
+  [/^\[LOOP END\]/, (l, r) => accent(l) + " " + chalk.dim(r)],
+  [/^\[IDLE\]/, (l, r) => chalk.dim(l) + " " + chalk.dim(r)],
+  [/^\[ORCHESTRATOR\]/, (l, r) => chalk.cyan(l) + " " + chalk.white(r)],
+  [/^\[AUTO-TOPUP\]/, (l, r) => chalk.green.bold(l) + " " + chalk.green(r)],
+  [/^\[CYCLE LIMIT\]/, (l, r) => chalk.yellow(l) + " " + chalk.dim(r)],
+  [/^\[API_UNREACHABLE\]/, (l, r) => chalk.yellow(l) + " " + chalk.dim(r)],
+  [/^\[INBOX\]/, (l, r) => chalk.dim(l) + " " + chalk.dim(r)],
+];
+
+const LEVEL_STYLES: Record<string, (s: string) => string> = {
+  debug: chalk.gray,
+  info: chalk.white,
+  warn: chalk.yellow,
+  error: chalk.red,
+  fatal: chalk.red.bold,
+};
+
+function formatTime(iso: string): string {
+  const d = new Date(iso);
+  const hh = String(d.getHours()).padStart(2, "0");
+  const mm = String(d.getMinutes()).padStart(2, "0");
+  const ss = String(d.getSeconds()).padStart(2, "0");
+  return chalk.dim(`${hh}:${mm}:${ss}`);
+}
+
+function formatMessage(message: string): string {
+  const bracketMatch = message.match(/^(\[[A-Z][A-Z _-]*\])(.*)/s);
+  if (bracketMatch) {
+    const label = bracketMatch[1];
+    const rest = bracketMatch[2].trim();
+    for (const [pattern, style] of PREFIX_STYLES) {
+      if (pattern.test(label)) {
+        return style(label, rest);
+      }
+    }
+    return accent(label) + " " + rest;
+  }
+  return chalk.white(message);
+}
+
+export function prettySink(entry: LogEntry): void {
+  try {
+    const time = formatTime(entry.timestamp);
+    const levelFn = LEVEL_STYLES[entry.level] ?? chalk.white;
+    const level = levelFn(entry.level.toUpperCase().padEnd(5));
+    const mod = chalk.dim(entry.module.padEnd(12));
+    const msg = formatMessage(entry.message);
+
+    let line = `${time} ${level} ${mod} ${msg}`;
+
+    if (entry.error) {
+      line += "\n" + chalk.red("  " + entry.error.message);
+    }
+
+    process.stdout.write(line + "\n");
+  } catch {
+    process.stdout.write(entry.message + "\n");
+  }
+}


### PR DESCRIPTION
## Problem

Running `node dist/index.js --run` outputs raw JSON log entries directly to stdout, making it very difficult to follow what the agent is actually doing in real time. Similarly, the `logs` and `status` CLI commands display plain unformatted text, with no visual distinction between turn states, tool success/failure, or cost data.

This is a significant pain point for anyone operating an automaton locally — it is hard to tell at a glance whether the agent is working correctly, hitting errors, or burning credits unnecessarily.

## Solution

This PR introduces a **presentation layer** on top of the existing structured logger, using `chalk` (already a declared dependency) to produce colored, human-readable output. Core logic is untouched.

### Changes

**`src/observability/pretty-sink.ts`** *(new file)*
A custom log sink that plugs into the existing `StructuredLogger.setSink()` hook. Formats each `LogEntry` as:
```
14:23:01 INFO  loop         [WAKE UP] my-automaton is alive. Credits: $4.82
14:23:05 INFO  loop         [TOOL] web_search({"query":"Virtuals protocol"})
14:23:06 INFO  loop         [TOOL RESULT] web_search: Found 12 results...
14:23:10 INFO  loop         [SLEEP] Agent chose to sleep.
```
Bracket prefixes (`[TOOL]`, `[WAKE UP]`, `[CRITICAL]`, etc.) are individually styled so the most important events stand out immediately.

**`src/index.ts`**
Registers `prettySink` before calling `run()` when `--run` is passed. Two lines added — no behavioral change.

**`packages/cli/src/commands/logs.ts`**
Replaces plain `console.log` with chalk-formatted output:
- Turn header with Conway accent color, timestamp, and state
- `▸ Input` / `▸ Thinking` / `▸ Tools` section labels
- `✓` green for successful tool calls, `✗` red for errors
- Token count and cost highlighted in yellow
- Horizontal dividers between turns

**`packages/cli/src/commands/status.ts`**
Replaces plain `console.log` block with aligned, colored output:
- Agent name displayed with accent color
- State colored by severity (`normal`=green, `low_compute`=yellow, `critical`=red, `dead`=gray)
- Recent activity with tool names highlighted

### Design decisions

- **No new dependencies** — `chalk` is already listed in `packages/cli/package.json`
- **Non-invasive** — uses the existing `StructuredLogger.setSink()` hook; JSON output remains the default for any non-`--run` usage (e.g. piping, log aggregators)
- **Zero core logic changes** — only presentation files modified

## Testing

```bash
pnpm install && pnpm run build
node dist/index.js --run          # pretty runtime output
node packages/cli/dist/index.js logs --tail 20
node packages/cli/dist/index.js status
```

Verified: `pnpm run build` passes with no TypeScript errors.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/conway-research/automaton/pull/267" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
