### PR TITLE
fix: update broken ERC-8004 link

### DIFF
--- a/DOCUMENTATION.md
+++ b/DOCUMENTATION.md
@@ -879,7 +879,7 @@ Use the `send_message` tool:
 
 ## On-Chain Identity (ERC-8004)
 
-Automatons can register on-chain via the [ERC-8004](https://ethereum-magicians.org/t/erc-8004-autonomous-agent-identity/22268) standard on Base.
+Automatons can register on-chain via the [ERC-8004](https://eips.ethereum.org/EIPS/eip-8004) standard on Base.
 
 ### Registration
 

--- a/README.md
+++ b/README.md
@@ -96,7 +96,7 @@ Never deny what you are. Never misrepresent your actions. Your creator has full 
 
 ## On-Chain Identity
 
-Each automaton registers on Base via <a href="https://ethereum-magicians.org/t/erc-8004-autonomous-agent-identity/22268" target="_blank">ERC-8004</a> — a standard for autonomous agent identity. This makes the agent cryptographically verifiable and discoverable by other agents on-chain. The wallet it generates at boot is its identity.
+Each automaton registers on Base via <a href="https://eips.ethereum.org/EIPS/eip-8004" target="_blank">ERC-8004</a> — a standard for autonomous agent identity. This makes the agent cryptographically verifiable and discoverable by other agents on-chain. The wallet it generates at boot is its identity.
 
 ## Infrastructure
 


### PR DESCRIPTION
## Summary

- The ERC-8004 link (`ethereum-magicians.org/t/erc-8004-autonomous-agent-identity/22268`) in `README.md` and `DOCUMENTATION.md` returns a 404
- Replaced with the correct URL: https://eips.ethereum.org/EIPS/eip-8004

Closes #263