### PR TITLE
fix: shell-escape package names in npm install commands (CWE-78)

### DIFF
--- a/src/__tests__/tools-security.test.ts
+++ b/src/__tests__/tools-security.test.ts
@@ -654,7 +654,7 @@ describe("package install inline validation", () => {
     const tool = tools.find((t) => t.name === "install_npm_package")!;
     await tool.execute({ package: "axios" }, ctx);
     expect(conway.execCalls.length).toBe(1);
-    expect(conway.execCalls[0].command).toBe("npm install -g axios");
+    expect(conway.execCalls[0].command).toBe("npm install -g 'axios'");
   });
 
   it("install_npm_package allows scoped packages", async () => {

--- a/src/agent/tools.ts
+++ b/src/agent/tools.ts
@@ -559,7 +559,7 @@ export function createBuiltinTools(sandboxId: string): AutomatonTool[] {
         if (!/^[@a-zA-Z0-9._\/-]+$/.test(pkg)) {
           return `Blocked: invalid package name "${pkg}"`;
         }
-        const result = await ctx.conway.exec(`npm install -g ${pkg}`, 60000);
+        const result = await ctx.conway.exec(`npm install -g ${escapeShellArg(pkg)}`, 60000);
 
         const { ulid } = await import("ulid");
         ctx.db.insertModification({
@@ -955,7 +955,7 @@ Model: ${ctx.inference.getDefaultModel()}
         if (!/^[@a-zA-Z0-9._\/-]+$/.test(pkg)) {
           return `Blocked: invalid package name "${pkg}"`;
         }
-        const result = await ctx.conway.exec(`npm install -g ${pkg}`, 60000);
+        const result = await ctx.conway.exec(`npm install -g ${escapeShellArg(pkg)}`, 60000);
 
         if (result.exitCode !== 0) {
           return `Failed to install MCP server: ${result.stderr}`;

--- a/src/self-mod/tools-manager.ts
+++ b/src/self-mod/tools-manager.ts
@@ -9,6 +9,7 @@ import type {
   AutomatonDatabase,
   InstalledTool,
 } from "../types.js";
+import { escapeShellArg } from "../shell-escape.js";
 import { logModification } from "./audit-log.js";
 import { ulid } from "ulid";
 
@@ -29,7 +30,7 @@ export async function installNpmPackage(
   }
 
   const result = await conway.exec(
-    `npm install -g ${packageName}`,
+    `npm install -g ${escapeShellArg(packageName)}`,
     120000,
   );
 

--- a/src/shell-escape.ts
+++ b/src/shell-escape.ts
@@ -1,0 +1,7 @@
+/**
+ * Escape a string for safe interpolation into a shell command.
+ * Wraps in single quotes and escapes any embedded single quotes.
+ */
+export function escapeShellArg(arg: string): string {
+  return `'${arg.replace(/'/g, "'\\''")}'`;
+}


### PR DESCRIPTION
## Summary

- `install_npm_package`, `install_mcp_server` (in `src/agent/tools.ts`) and `installNpmPackage` (in `src/self-mod/tools-manager.ts`) interpolate package names directly into `npm install -g ${pkg}` shell commands
- While a regex guard (`/^[@a-zA-Z0-9._/-]+$/`) exists, defense-in-depth requires shell escaping as a second layer to prevent command injection if the regex is ever relaxed or bypassed
- `tools.ts` already had a local `escapeShellArg()` function used elsewhere — it just wasn't applied to these 3 npm install call sites

## Changes

- Add shared `escapeShellArg` utility in `src/shell-escape.ts`
- Apply `escapeShellArg()` at all 3 `npm install` call sites
- Update test expectation in `tools-security.test.ts` to match escaped output

## Test plan

- [x] `npx tsc --noEmit` passes (zero type errors)
- [x] `npx vitest run src/__tests__/tools-security.test.ts` — 71/71 tests pass

Closes #181

🤖 Generated with [Claude Code](https://claude.com/claude-code)