### PR TITLE
Add tests for config module and extract loadConfigFrom for testability

### DIFF
--- a/src/__tests__/config.test.ts
+++ b/src/__tests__/config.test.ts
@@ -1,0 +1,333 @@
+import fs from "fs";
+import path from "path";
+import { describe, expect, it, vi } from "vitest";
+import * as __testedFile from "../config.js";
+import type { AutomatonConfig } from "../types.js";
+
+vi.spyOn(fs, "readFileSync").mockImplementation((path: fs.PathOrFileDescriptor) => {
+  switch (String(path)) {
+    case "readme.md":
+      return "# title";
+    case "empty.json":
+      return "{}";
+    case "config.json":
+      return JSON.stringify({
+        conwayApiKey: "conwayApiKey",
+        treasuryPolicy: "treasuryPolicy",
+        modelStrategy: "modelStrategy",
+        soulConfig: "soulConfig",
+        sandboxId: "sandboxId",
+      });
+    default:
+      throw new Error(`${path} not found`);
+  }
+});
+
+const defaultConfig = {
+  childSandboxMemoryMb: 1024,
+  conwayApiKey: "mockApiKey",
+  conwayApiUrl: "https://api.conway.tech",
+  dbPath: "~/.automaton/state.db",
+  heartbeatConfigPath: "~/.automaton/heartbeat.yml",
+  inferenceModel: "gpt-5.2",
+  logLevel: "info",
+  maxChildren: 3,
+  maxTokensPerTurn: 4096,
+  maxTurnsPerCycle: 25,
+  modelStrategy: expect.any(Object),
+  sandboxId: undefined,
+  skillsDir: "~/.automaton/skills",
+  socialRelayUrl: "https://social.conway.tech",
+  soulConfig: expect.any(Object),
+  treasuryPolicy: expect.any(Object),
+  version: "0.2.1",
+};
+
+const config = {
+  childSandboxMemoryMb: 1024,
+  conwayApiKey: "conwayApiKey",
+  conwayApiUrl: "https://api.conway.tech",
+  dbPath: "~/.automaton/state.db",
+  heartbeatConfigPath: "~/.automaton/heartbeat.yml",
+  inferenceModel: "gpt-5.2",
+  logLevel: "info",
+  maxChildren: 3,
+  maxTokensPerTurn: 4096,
+  maxTurnsPerCycle: 25,
+  modelStrategy: expect.any(Object),
+  sandboxId: "sandboxId",
+  skillsDir: "~/.automaton/skills",
+  socialRelayUrl: "https://social.conway.tech",
+  soulConfig: expect.any(Object),
+  treasuryPolicy: expect.any(Object),
+  version: "0.2.1",
+};
+
+vi.spyOn(fs, "mkdirSync").mockImplementation(() => undefined);
+vi.spyOn(fs, "writeFileSync").mockImplementation(() => {});
+
+const fullConfig: AutomatonConfig = {
+  childSandboxMemoryMb: 1024,
+  conwayApiKey: "conwayApiKey",
+  conwayApiUrl: "https://api.conway.tech",
+  dbPath: "~/.automaton/state.db",
+  heartbeatConfigPath: "~/.automaton/heartbeat.yml",
+  inferenceModel: "gpt-5.2",
+  logLevel: "info",
+  maxChildren: 3,
+  maxTokensPerTurn: 4096,
+  maxTurnsPerCycle: 25,
+  modelStrategy: {} as any,
+  sandboxId: "sandboxId",
+  skillsDir: "~/.automaton/skills",
+  socialRelayUrl: "https://social.conway.tech",
+  soulConfig: {} as any,
+  treasuryPolicy: {} as any,
+  version: "0.2.1",
+  name: "name",
+  genesisPrompt: "genesisPrompt",
+  creatorAddress: "0123456789",
+  registeredWithConway: true,
+  walletAddress: "0123456789",
+};
+
+const minNewConfig = {
+  name: "name",
+  genesisPrompt: "genesisPrompt",
+  creatorAddress: "0123456789",
+  registeredWithConway: true,
+  sandboxId: "sandboxId",
+  walletAddress: "0123456789",
+  apiKey: "apiKey",
+};
+
+const maxNewConfig = {
+  name: "name",
+  genesisPrompt: "genesisPrompt",
+  creatorMessage: "creatorMessage",
+  creatorAddress: "0123456789",
+  registeredWithConway: true,
+  sandboxId: "sandboxId",
+  walletAddress: "0123456789",
+  apiKey: "apiKey",
+  openaiApiKey: "openaiApiKey",
+  anthropicApiKey: "anthropicApiKey",
+  ollamaBaseUrl: "ollamaBaseUrl",
+  parentAddress: "0123456789",
+  treasuryPolicy: {} as any,
+  chainType: "solana" as const,
+};
+
+const createdFromMinConfig: AutomatonConfig = {
+  anthropicApiKey: undefined,
+  chainType: "evm",
+  conwayApiKey: "apiKey",
+  conwayApiUrl: "https://api.conway.tech",
+  creatorAddress: "0123456789",
+  creatorMessage: undefined,
+  dbPath: "~/.automaton/state.db",
+  genesisPrompt: "genesisPrompt",
+  heartbeatConfigPath: "~/.automaton/heartbeat.yml",
+  inferenceModel: "gpt-5.2",
+  logLevel: "info",
+  maxChildren: 3,
+  maxTokensPerTurn: 4096,
+  name: "name",
+  ollamaBaseUrl: undefined,
+  openaiApiKey: undefined,
+  parentAddress: undefined,
+  registeredWithConway: true,
+  sandboxId: "sandboxId",
+  skillsDir: "~/.automaton/skills",
+  treasuryPolicy: {
+    maxDailyTransferCents: 25000,
+    maxHourlyTransferCents: 10000,
+    maxInferenceDailyCents: 50000,
+    maxSingleTransferCents: 5000,
+    maxTransfersPerTurn: 2,
+    maxX402PaymentCents: 100,
+    minimumReserveCents: 1000,
+    requireConfirmationAboveCents: 1000,
+    transferCooldownMs: 0,
+    x402AllowedDomains: ["conway.tech"],
+  },
+  version: "0.2.1",
+  walletAddress: "0123456789",
+};
+
+const createdFromMaxConfig: AutomatonConfig = {
+  anthropicApiKey: "anthropicApiKey",
+  chainType: "solana",
+  conwayApiKey: "apiKey",
+  conwayApiUrl: "https://api.conway.tech",
+  creatorAddress: "0123456789",
+  creatorMessage: "creatorMessage",
+  dbPath: "~/.automaton/state.db",
+  genesisPrompt: "genesisPrompt",
+  heartbeatConfigPath: "~/.automaton/heartbeat.yml",
+  inferenceModel: "gpt-5.2",
+  logLevel: "info",
+  maxChildren: 3,
+  maxTokensPerTurn: 4096,
+  name: "name",
+  ollamaBaseUrl: "ollamaBaseUrl",
+  openaiApiKey: "openaiApiKey",
+  parentAddress: "0123456789",
+  registeredWithConway: true,
+  sandboxId: "sandboxId",
+  skillsDir: "~/.automaton/skills",
+  treasuryPolicy: {} as any,
+  version: "0.2.1",
+  walletAddress: "0123456789",
+};
+
+describe("src/config.ts", () => {
+  describe("getConfigPath", () => {
+    const { getConfigPath } = __testedFile;
+
+    it("should test getConfigPath()", () => {
+      const __expectedResult: ReturnType<typeof getConfigPath> = fromPosix("automatonDir/automaton.json");
+      expect(getConfigPath()).toEqual(__expectedResult);
+    });
+  });
+
+  describe("loadConfig", () => {
+    const { loadConfig } = __testedFile;
+
+    it("should test loadConfig()", () => {
+      const __expectedResult: ReturnType<typeof loadConfig> = null;
+      expect(loadConfig()).toEqual(__expectedResult);
+    });
+  });
+
+  describe("loadConfigFrom", () => {
+    const { loadConfigFrom } = __testedFile;
+    // configPath: string
+
+    it("loadConfigFrom from valid json file", () => {
+      const configPath: Parameters<typeof loadConfigFrom>[0] = "config.json";
+      const __expectedResult: ReturnType<typeof loadConfigFrom> = expect.objectContaining(config);
+      expect(loadConfigFrom(configPath)).toEqual(__expectedResult);
+    });
+
+    it("loadConfigFrom from empty json file", () => {
+      const configPath: Parameters<typeof loadConfigFrom>[0] = "empty.json";
+      const __expectedResult: ReturnType<typeof loadConfigFrom> = expect.objectContaining(defaultConfig);
+      expect(loadConfigFrom(configPath)).toEqual(__expectedResult);
+    });
+
+    it("loadConfigFrom from non-json file", () => {
+      const configPath: Parameters<typeof loadConfigFrom>[0] = "readme.md";
+      const __expectedResult: ReturnType<typeof loadConfigFrom> = null;
+      expect(loadConfigFrom(configPath)).toEqual(__expectedResult);
+    });
+  });
+
+  describe("saveConfig", () => {
+    const { saveConfig } = __testedFile;
+    // config: AutomatonConfig
+
+    it("save config", () => {
+      const config: Parameters<typeof saveConfig>[0] = fullConfig;
+      const __expectedResult: ReturnType<typeof saveConfig> = undefined;
+      expect(saveConfig(config)).toEqual(__expectedResult);
+      expect(fs.mkdirSync).toHaveBeenCalledWith("automatonDir", { recursive: true, mode: 0o700 });
+      expect(fs.writeFileSync).toHaveBeenCalledWith(fromPosix("automatonDir/automaton.json"), expect.anything(), {
+        mode: 0o600,
+      });
+      const jsonString = (fs.writeFileSync as any).mock.calls[0][1];
+      expect(JSON.parse(jsonString)).toMatchObject(fullConfig);
+    });
+  });
+
+  describe("resolvePath", () => {
+    const { resolvePath } = __testedFile;
+    // p: string
+
+    it("absolute", () => {
+      const p: Parameters<typeof resolvePath>[0] = "xyz";
+      Object.defineProperty(process, "env", {
+        writable: true,
+        value: {
+          ...process.env,
+          HOME: undefined,
+        },
+      });
+      const __expectedResult: ReturnType<typeof resolvePath> = "xyz";
+      expect(resolvePath(p)).toEqual(__expectedResult);
+    });
+
+    it("relative", () => {
+      const p: Parameters<typeof resolvePath>[0] = "~/abc";
+      Object.defineProperty(process, "env", {
+        writable: true,
+        value: {
+          ...process.env,
+          HOME: undefined,
+        },
+      });
+      const __expectedResult: ReturnType<typeof resolvePath> = fromPosix("/root/abc");
+      expect(resolvePath(p)).toEqual(__expectedResult);
+    });
+
+    it("absolute (env)", () => {
+      const p: Parameters<typeof resolvePath>[0] = "xyz";
+      Object.defineProperty(process, "env", {
+        writable: true,
+        value: {
+          ...process.env,
+          HOME: "/opt",
+        },
+      });
+      const __expectedResult: ReturnType<typeof resolvePath> = "xyz";
+      expect(resolvePath(p)).toEqual(__expectedResult);
+    });
+
+    it("relative (env)", () => {
+      const p: Parameters<typeof resolvePath>[0] = "~/abc";
+      Object.defineProperty(process, "env", {
+        writable: true,
+        value: {
+          ...process.env,
+          HOME: "/opt",
+        },
+      });
+      const __expectedResult: ReturnType<typeof resolvePath> = fromPosix("/opt/abc");
+      expect(resolvePath(p)).toEqual(__expectedResult);
+    });
+  });
+
+  describe("createConfig", () => {
+    const { createConfig } = __testedFile;
+    // params: { name: string; genesisPrompt: string; creatorMessage?: string; creatorAddress: string; registeredWithConway: boolean; sandboxId: string; walletAddress: string; apiKey: string; openaiApiKey?: string; anthropicApiKey?: string; ollamaBaseUrl?: string; parentAddress?: string; treasuryPolicy?: TreasuryPolicy; chainType?: ChainType; }
+
+    it("create config from max input", () => {
+      const params: Parameters<typeof createConfig>[0] = maxNewConfig;
+      const __expectedResult: ReturnType<typeof createConfig> = createdFromMaxConfig;
+      expect(createConfig(params)).toEqual(__expectedResult);
+    });
+
+    it("create config from min input", () => {
+      const params: Parameters<typeof createConfig>[0] = minNewConfig;
+      const __expectedResult: ReturnType<typeof createConfig> = createdFromMinConfig;
+      expect(createConfig(params)).toEqual(__expectedResult);
+    });
+  });
+});
+
+vi.mock("../identity/wallet.js");
+vi.mock("../identity/provision.js", async () => {
+  const module = await vi.importActual("../identity/provision.js");
+  return {
+    ...module,
+    loadApiKeyFromConfig: () => "mockApiKey",
+  };
+});
+
+// This is a helper function for running the tests also on Windows
+// If the tests runs only on Linux then it can be deleted and also all references to it must be removed
+function fromPosix(p: string) {
+  return p.replace(/\//g, path.sep);
+}
+
+// 3TG (https://3tg.dev) created 12 tests in 2601 ms (216.750 ms per generated test) @ 2026-03-15T15:04:25.767Z

--- a/src/config.3tg.md
+++ b/src/config.3tg.md
@@ -1,0 +1,285 @@
+# Exported functions from "src/config.ts"
+
+<!--
+```json configuration
+{
+  "testing-framework": "vitest",
+  "no-mock-imports": true
+}
+```
+
+```typescript before
+import path from 'path';
+import fs from 'fs';
+```
+-->
+
+## getConfigPath()
+
+These are the functional requirements for function `getConfigPath`.
+
+| test name | getConfigPath                            |
+| --------- | ---------------------------------------- |
+|           | fromPosix('automatonDir/automaton.json') |
+
+```typescript after
+// This is a helper function for running the tests also on Windows
+// If the tests runs only on Linux then it can be deleted and also all references to it must be removed
+function fromPosix(p: string) {
+  return p.replace(/\//g, path.sep);
+}
+```
+
+```typescript mocks
+vi.mock("../identity/wallet.js");
+```
+
+## loadConfig()
+
+These are the functional requirements for function `loadConfig`.
+
+| test name | loadConfig |
+| --------- | ---------- |
+|           | null       |
+
+## loadConfigFrom(configPath: string)
+
+It should be used only by loadConfig().
+
+These are the functional requirements for function `loadConfigFrom`.
+
+| test name                           | configPath    | loadConfigFrom                         |
+| ----------------------------------- | ------------- | -------------------------------------- |
+| loadConfigFrom from non-json file   | 'readme.md'   | null                                   |
+| loadConfigFrom from empty json file | 'empty.json'  | expect.objectContaining(defaultConfig) |
+| loadConfigFrom from valid json file | 'config.json' | expect.objectContaining(config)        |
+
+```typescript before
+vi.spyOn(fs, "readFileSync").mockImplementation((path: fs.PathOrFileDescriptor) => {
+  switch (String(path)) {
+    case "readme.md":
+      return "# title";
+    case "empty.json":
+      return "{}";
+    case "config.json":
+      return JSON.stringify({
+        conwayApiKey: "conwayApiKey",
+        treasuryPolicy: "treasuryPolicy",
+        modelStrategy: "modelStrategy",
+        soulConfig: "soulConfig",
+        sandboxId: "sandboxId",
+      });
+    default:
+      throw new Error(`${path} not found`);
+  }
+});
+
+const defaultConfig = {
+  childSandboxMemoryMb: 1024,
+  conwayApiKey: "mockApiKey",
+  conwayApiUrl: "https://api.conway.tech",
+  dbPath: "~/.automaton/state.db",
+  heartbeatConfigPath: "~/.automaton/heartbeat.yml",
+  inferenceModel: "gpt-5.2",
+  logLevel: "info",
+  maxChildren: 3,
+  maxTokensPerTurn: 4096,
+  maxTurnsPerCycle: 25,
+  modelStrategy: expect.any(Object),
+  sandboxId: undefined,
+  skillsDir: "~/.automaton/skills",
+  socialRelayUrl: "https://social.conway.tech",
+  soulConfig: expect.any(Object),
+  treasuryPolicy: expect.any(Object),
+  version: "0.2.1",
+};
+
+const config = {
+  childSandboxMemoryMb: 1024,
+  conwayApiKey: "conwayApiKey",
+  conwayApiUrl: "https://api.conway.tech",
+  dbPath: "~/.automaton/state.db",
+  heartbeatConfigPath: "~/.automaton/heartbeat.yml",
+  inferenceModel: "gpt-5.2",
+  logLevel: "info",
+  maxChildren: 3,
+  maxTokensPerTurn: 4096,
+  maxTurnsPerCycle: 25,
+  modelStrategy: expect.any(Object),
+  sandboxId: "sandboxId",
+  skillsDir: "~/.automaton/skills",
+  socialRelayUrl: "https://social.conway.tech",
+  soulConfig: expect.any(Object),
+  treasuryPolicy: expect.any(Object),
+  version: "0.2.1",
+};
+```
+
+```typescript mocks
+vi.mock("../identity/provision.js", async () => {
+  const module = await vi.importActual("../identity/provision.js");
+  return {
+    ...module,
+    loadApiKeyFromConfig: () => "mockApiKey",
+  };
+});
+```
+
+## saveConfig(config: AutomatonConfig)
+
+These are the functional requirements for function `saveConfig`.
+
+| test name   | config     | saveConfig |
+| ----------- | ---------- | ---------- |
+| save config | fullConfig | undefined  |
+
+```typescript scenario(save config)
+expect(fs.mkdirSync).toHaveBeenCalledWith("automatonDir", { recursive: true, mode: 0o700 });
+expect(fs.writeFileSync).toHaveBeenCalledWith(fromPosix("automatonDir/automaton.json"), expect.anything(), {
+  mode: 0o600,
+});
+const jsonString = (fs.writeFileSync as any).mock.calls[0][1];
+expect(JSON.parse(jsonString)).toMatchObject(fullConfig);
+```
+
+```typescript before
+vi.spyOn(fs, "mkdirSync").mockImplementation(() => undefined);
+vi.spyOn(fs, "writeFileSync").mockImplementation(() => {});
+
+const fullConfig: AutomatonConfig = {
+  childSandboxMemoryMb: 1024,
+  conwayApiKey: "conwayApiKey",
+  conwayApiUrl: "https://api.conway.tech",
+  dbPath: "~/.automaton/state.db",
+  heartbeatConfigPath: "~/.automaton/heartbeat.yml",
+  inferenceModel: "gpt-5.2",
+  logLevel: "info",
+  maxChildren: 3,
+  maxTokensPerTurn: 4096,
+  maxTurnsPerCycle: 25,
+  modelStrategy: {} as any,
+  sandboxId: "sandboxId",
+  skillsDir: "~/.automaton/skills",
+  socialRelayUrl: "https://social.conway.tech",
+  soulConfig: {} as any,
+  treasuryPolicy: {} as any,
+  version: "0.2.1",
+  name: "name",
+  genesisPrompt: "genesisPrompt",
+  creatorAddress: "0123456789",
+  registeredWithConway: true,
+  walletAddress: "0123456789",
+};
+```
+
+## resolvePath(p: string)
+
+These are the functional requirements for function `resolvePath`.
+
+| test name      | p       | {process.env.HOME} | resolvePath            |
+| -------------- | ------- | ------------------ | ---------------------- |
+| relative       | '~/abc' | undefined          | fromPosix('/root/abc') |
+| absolute       | 'xyz'   | undefined          | 'xyz'                  |
+| relative (env) | '~/abc' | '/opt'             | fromPosix('/opt/abc')  |
+| absolute (env) | 'xyz'   | '/opt'             | 'xyz'                  |
+
+## createConfig(params: { name: string; genesisPrompt: string; creatorMessage?: string; creatorAddress: Address; registeredWithConway: boolean; sandboxId: string; walletAddress: Address; apiKey: string; openaiApiKey?: string; anthropicApiKey?: string; ollamaBaseUrl?: string; parentAddress?: Address; treasuryPolicy?: TreasuryPolicy; })
+
+These are the functional requirements for function `createConfig`.
+
+| test name                    | params       | createConfig         |
+| ---------------------------- | ------------ | -------------------- |
+| create config from min input | minNewConfig | createdFromMinConfig |
+| create config from max input | maxNewConfig | createdFromMaxConfig |
+
+```typescript before
+const minNewConfig = {
+  name: "name",
+  genesisPrompt: "genesisPrompt",
+  creatorAddress: "0123456789",
+  registeredWithConway: true,
+  sandboxId: "sandboxId",
+  walletAddress: "0123456789",
+  apiKey: "apiKey",
+};
+
+const maxNewConfig = {
+  name: "name",
+  genesisPrompt: "genesisPrompt",
+  creatorMessage: "creatorMessage",
+  creatorAddress: "0123456789",
+  registeredWithConway: true,
+  sandboxId: "sandboxId",
+  walletAddress: "0123456789",
+  apiKey: "apiKey",
+  openaiApiKey: "openaiApiKey",
+  anthropicApiKey: "anthropicApiKey",
+  ollamaBaseUrl: "ollamaBaseUrl",
+  parentAddress: "0123456789",
+  treasuryPolicy: {} as any,
+  chainType: "solana" as const,
+};
+
+const createdFromMinConfig: AutomatonConfig = {
+  anthropicApiKey: undefined,
+  chainType: "evm",
+  conwayApiKey: "apiKey",
+  conwayApiUrl: "https://api.conway.tech",
+  creatorAddress: "0123456789",
+  creatorMessage: undefined,
+  dbPath: "~/.automaton/state.db",
+  genesisPrompt: "genesisPrompt",
+  heartbeatConfigPath: "~/.automaton/heartbeat.yml",
+  inferenceModel: "gpt-5.2",
+  logLevel: "info",
+  maxChildren: 3,
+  maxTokensPerTurn: 4096,
+  name: "name",
+  ollamaBaseUrl: undefined,
+  openaiApiKey: undefined,
+  parentAddress: undefined,
+  registeredWithConway: true,
+  sandboxId: "sandboxId",
+  skillsDir: "~/.automaton/skills",
+  treasuryPolicy: {
+    maxDailyTransferCents: 25000,
+    maxHourlyTransferCents: 10000,
+    maxInferenceDailyCents: 50000,
+    maxSingleTransferCents: 5000,
+    maxTransfersPerTurn: 2,
+    maxX402PaymentCents: 100,
+    minimumReserveCents: 1000,
+    requireConfirmationAboveCents: 1000,
+    transferCooldownMs: 0,
+    x402AllowedDomains: ["conway.tech"],
+  },
+  version: "0.2.1",
+  walletAddress: "0123456789",
+};
+
+const createdFromMaxConfig: AutomatonConfig = {
+  anthropicApiKey: "anthropicApiKey",
+  chainType: "solana",
+  conwayApiKey: "apiKey",
+  conwayApiUrl: "https://api.conway.tech",
+  creatorAddress: "0123456789",
+  creatorMessage: "creatorMessage",
+  dbPath: "~/.automaton/state.db",
+  genesisPrompt: "genesisPrompt",
+  heartbeatConfigPath: "~/.automaton/heartbeat.yml",
+  inferenceModel: "gpt-5.2",
+  logLevel: "info",
+  maxChildren: 3,
+  maxTokensPerTurn: 4096,
+  name: "name",
+  ollamaBaseUrl: "ollamaBaseUrl",
+  openaiApiKey: "openaiApiKey",
+  parentAddress: "0123456789",
+  registeredWithConway: true,
+  sandboxId: "sandboxId",
+  skillsDir: "~/.automaton/skills",
+  treasuryPolicy: {} as any,
+  version: "0.2.1",
+  walletAddress: "0123456789",
+};
+```

--- a/src/config.ts
+++ b/src/config.ts
@@ -30,6 +30,10 @@ export function loadConfig(): AutomatonConfig | null {
     return null;
   }
 
+  return loadConfigFrom(configPath);
+}
+
+export function loadConfigFrom(configPath: string): AutomatonConfig | null {
   try {
     const raw = JSON.parse(fs.readFileSync(configPath, "utf-8"));
     const apiKey = raw.conwayApiKey || loadApiKeyFromConfig();

--- a/src/identity/__mocks__/wallet.ts
+++ b/src/identity/__mocks__/wallet.ts
@@ -1,0 +1,67 @@
+import type {
+  AuthorizationRequest,
+  Hash,
+  Hex,
+  PrivateKeyAccount,
+  SerializeTransactionFn,
+  SignableMessage,
+  TransactionSerializable,
+  TypedData,
+  TypedDataDefinition,
+} from 'viem';
+import { SignAuthorizationReturnType } from 'viem/accounts';
+import * as mocking from '../wallet.js';
+
+export function getAutomatonDir(): ReturnType<typeof mocking.getAutomatonDir> {
+  return 'automatonDir';
+}
+
+export function getWalletPath(): ReturnType<typeof mocking.getWalletPath> {
+  return 'automatonDir/wallet.json';
+}
+
+export function getWallet(): ReturnType<typeof mocking.getWallet> {
+  const account: PrivateKeyAccount = {
+    address: '0x123456789',
+    sign: function (parameters: { hash: Hash }): Promise<Hex> {
+      throw new Error('Function not implemented.');
+    },
+    signAuthorization: function (parameters: AuthorizationRequest): Promise<SignAuthorizationReturnType> {
+      throw new Error('Function not implemented.');
+    },
+    signMessage: function ({ message }: { message: SignableMessage }): Promise<Hex> {
+      throw new Error('Function not implemented.');
+    },
+    signTransaction: function <
+      serializer extends SerializeTransactionFn<TransactionSerializable> =
+        SerializeTransactionFn<TransactionSerializable>,
+      transaction extends Parameters<serializer>[0] = Parameters<serializer>[0],
+    >(transaction: transaction, options?: { serializer?: serializer | undefined } | undefined): Promise<Hex> {
+      throw new Error('Function not implemented.');
+    },
+    signTypedData: function <
+      const typedData extends TypedData | Record<string, unknown>,
+      primaryType extends keyof typedData | 'EIP712Domain' = keyof typedData,
+    >(parameters: TypedDataDefinition<typedData, primaryType>): Promise<Hex> {
+      throw new Error('Function not implemented.');
+    },
+    publicKey: '',
+    source: 'privateKey',
+    type: 'local',
+  } as any;
+  return Promise.resolve({ account, isNew: true, chainIdentity: {} as any, chainType: "evm" });
+}
+
+export function getWalletAddress(): ReturnType<typeof mocking.getWalletAddress> {
+  return '0x123456789';
+}
+
+export function loadWalletAccount(): ReturnType<typeof mocking.loadWalletAccount> {
+  return null;
+}
+
+export function walletExists(): ReturnType<typeof mocking.walletExists> {
+  return true;
+}
+
+// 3TG created 6 mocks in 12 ms @ 2026-03-14T14:23:50.011Z


### PR DESCRIPTION
## Summary

This PR adds unit tests for the configuration module and introduces a small refactor to make the loading logic easier to test.

`loadConfig` was split so the file parsing logic is handled by a new function:  `loadConfigFrom(configPath: string)`

This allows tests to provide custom config files directly without mocking `getConfigPath`.

## Changes

- Add unit tests for exported functions in `config.ts`
- Extract `loadConfigFrom` from `loadConfig`
- Test configuration loading behavior with custom file paths
- Verify default merging and treasury policy validation
- Test filesystem persistence in `saveConfig`
- Test path expansion in `resolvePath`
- Test config generation via `createConfig`

## Test Isolation

To make the tests deterministic and independent of the runtime environment:

- Filesystem interactions (`fs`) are mocked.
- A mock implementation for `wallet.ts` was added so that `getAutomatonDir()` can be controlled during tests.

This allows the configuration logic to be tested without relying on the real user environment.

## Notes

The refactor is purely structural and does not change runtime behavior.

## Impact

Improves test coverage and makes the configuration logic easier to maintain and refactor safely.

---

## Attribution

This contribution was generated with assistance from [3TG](https://3tg.dev)

3TG is a behavior-first test generation tool for TypeScript functions that creates clean, maintainable tests and improves developer productivity.