### PR TITLE
cli: validate addresses before send and fund

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,6 +17,14 @@
     "./state/database.js": {
       "types": "./dist/state/database.d.ts",
       "default": "./dist/state/database.js"
+    },
+    "./identity/chain.js": {
+      "types": "./dist/identity/chain.d.ts",
+      "default": "./dist/identity/chain.js"
+    },
+    "./social/validation.js": {
+      "types": "./dist/social/validation.d.ts",
+      "default": "./dist/social/validation.js"
     }
   },
   "bin": {

--- a/packages/cli/src/commands/fund.ts
+++ b/packages/cli/src/commands/fund.ts
@@ -5,6 +5,7 @@
  */
 
 import { loadConfig } from "@conway/automaton/config.js";
+import { isValidAddress } from "@conway/automaton/identity/chain.js";
 
 const args = process.argv.slice(3);
 const amount = args[0];
@@ -37,6 +38,11 @@ if (amountCents <= 0) {
 }
 
 const destination = toAddress || config.walletAddress;
+
+if (!isValidAddress(destination)) {
+  console.log(`Invalid destination address: ${destination}`);
+  process.exit(1);
+}
 
 const payload = {
   to_address: destination,

--- a/packages/cli/src/commands/send.ts
+++ b/packages/cli/src/commands/send.ts
@@ -8,6 +8,8 @@
  */
 
 import { loadConfig } from "@conway/automaton/config.js";
+import { isValidAddress } from "@conway/automaton/identity/chain.js";
+import { validateRelayUrl } from "@conway/automaton/social/validation.js";
 import { privateKeyToAccount, type PrivateKeyAccount } from "viem/accounts";
 import { keccak256, toBytes } from "viem";
 import fs from "fs";
@@ -21,6 +23,11 @@ if (!toAddress || !messageText) {
   console.log("Usage: automaton-cli send <to-address> <message>");
   console.log("Examples:");
   console.log('  automaton-cli send 0xabc...def "Hello, fellow automaton!"');
+  process.exit(1);
+}
+
+if (!isValidAddress(toAddress)) {
+  console.log(`Invalid recipient address: ${toAddress}`);
   process.exit(1);
 }
 
@@ -46,6 +53,8 @@ const relayUrl =
   config?.socialRelayUrl ||
   process.env.SOCIAL_RELAY_URL ||
   "https://social.conway.tech";
+
+validateRelayUrl(relayUrl);
 
 try {
   // Phase 3.2: Sign the message using the same canonical format as runtime

--- a/packages/cli/src/runtime-shims.d.ts
+++ b/packages/cli/src/runtime-shims.d.ts
@@ -56,3 +56,13 @@ declare module "@conway/automaton/state/database.js" {
 
   export function createDatabase(path: string): AutomatonCliDatabase;
 }
+
+declare module "@conway/automaton/identity/chain.js" {
+  export type ChainType = "evm" | "solana";
+
+  export function isValidAddress(address: string, chainType?: ChainType): boolean;
+}
+
+declare module "@conway/automaton/social/validation.js" {
+  export function validateRelayUrl(url: string): void;
+}

--- a/src/__tests__/cli-commands.test.ts
+++ b/src/__tests__/cli-commands.test.ts
@@ -1,0 +1,96 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const originalArgv = process.argv.slice();
+const originalExit = process.exit;
+
+describe("creator CLI command validation", () => {
+  beforeEach(() => {
+    vi.resetModules();
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    process.argv = originalArgv.slice();
+    process.exit = originalExit;
+    vi.unstubAllGlobals();
+    vi.restoreAllMocks();
+    vi.resetModules();
+  });
+
+  it("send exits early for an invalid recipient address", async () => {
+    const logSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+    const exitSpy = vi
+      .spyOn(process, "exit")
+      .mockImplementation(((code?: number) => {
+        throw new Error(`process.exit:${code ?? 0}`);
+      }) as typeof process.exit);
+
+    process.argv = ["node", "automaton-cli", "send", "not-an-address", "hello"];
+
+    vi.doMock("@conway/automaton/config.js", () => ({
+      loadConfig: () => ({
+        socialRelayUrl: "https://social.conway.tech",
+      }),
+    }));
+    vi.doMock("@conway/automaton/identity/chain.js", () => ({
+      isValidAddress: () => false,
+    }));
+    vi.doMock("@conway/automaton/social/validation.js", () => ({
+      validateRelayUrl: vi.fn(),
+    }));
+    vi.doMock("viem/accounts", () => ({
+      privateKeyToAccount: vi.fn(),
+    }));
+    vi.doMock("viem", () => ({
+      keccak256: vi.fn(),
+      toBytes: vi.fn(),
+    }));
+    vi.doMock("fs", () => ({
+      default: {
+        existsSync: vi.fn(),
+        readFileSync: vi.fn(),
+      },
+    }));
+    vi.doMock("path", () => ({
+      default: {
+        join: vi.fn(),
+      },
+    }));
+
+    await expect(import("../../packages/cli/src/commands/send.ts")).rejects.toThrow("process.exit:1");
+
+    expect(exitSpy).toHaveBeenCalledWith(1);
+    expect(logSpy).toHaveBeenCalledWith("Invalid recipient address: not-an-address");
+  });
+
+  it("fund exits before fetch when the destination address is invalid", async () => {
+    const logSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+    const exitSpy = vi
+      .spyOn(process, "exit")
+      .mockImplementation(((code?: number) => {
+        throw new Error(`process.exit:${code ?? 0}`);
+      }) as typeof process.exit);
+    const fetchSpy = vi.fn();
+
+    process.argv = ["node", "automaton-cli", "fund", "5.00", "--to", "not-an-address"];
+    vi.stubGlobal("fetch", fetchSpy);
+
+    vi.doMock("@conway/automaton/config.js", () => ({
+      loadConfig: () => ({
+        name: "Test Automaton",
+        walletAddress: "0x1234567890123456789012345678901234567890",
+        conwayApiKey: "test-api-key",
+        conwayApiUrl: "https://api.conway.tech",
+      }),
+    }));
+    vi.doMock("@conway/automaton/identity/chain.js", () => ({
+      isValidAddress: () => false,
+    }));
+
+    await expect(import("../../packages/cli/src/commands/fund.ts")).rejects.toThrow("process.exit:1");
+
+    expect(exitSpy).toHaveBeenCalledWith(1);
+    expect(logSpy).toHaveBeenCalledWith("Invalid destination address: not-an-address");
+    expect(fetchSpy).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
Adds early validation to the creator CLI so invalid addresses fail fast instead of making network requests.

This covers:
- `automaton-cli send`
- `automaton-cli fund`
- relay URL validation in `send`
- a small CLI test file for invalid address handling

Validated with `pnpm install`, `pnpm typecheck`, `pnpm build`, and `pnpm test src/__tests__/cli-commands.test.ts`.

I also tried `pnpm test -- cli-commands`, but that surfaced unrelated existing failures in the repo.
