### PR TITLE
feat: add Exa AI-powered search tool

### DIFF
--- a/src/__tests__/exa-search.test.ts
+++ b/src/__tests__/exa-search.test.ts
@@ -1,0 +1,380 @@
+/**
+ * Exa Search Tool Tests
+ *
+ * Tests for the Exa AI-powered web search tool:
+ * - API response parsing
+ * - Content/snippet fallback logic
+ * - Disabled state when EXA_API_KEY is unset
+ * - Tool registration and risk level
+ */
+
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import {
+  exaSearch,
+  extractSnippet,
+  formatResults,
+  type ExaSearchResult,
+  type ExaSearchResponse,
+} from "../agent/exa-search.js";
+import { createBuiltinTools, executeTool } from "../agent/tools.js";
+import {
+  MockInferenceClient,
+  MockConwayClient,
+  createTestDb,
+  createTestIdentity,
+  createTestConfig,
+} from "./mocks.js";
+import type { AutomatonTool, ToolContext } from "../types.js";
+
+// Mock erc8004.js to avoid ABI parse error (same as other test files)
+vi.mock("../registry/erc8004.js", () => ({
+  queryAgent: vi.fn(),
+  getTotalAgents: vi.fn().mockResolvedValue(0),
+  registerAgent: vi.fn(),
+  leaveFeedback: vi.fn(),
+}));
+
+// ─── Fixture Data ───────────────────────────────────────────────
+
+const MOCK_API_RESPONSE = {
+  requestId: "req_test_123",
+  results: [
+    {
+      title: "Introduction to Neural Search",
+      url: "https://example.com/neural-search",
+      publishedDate: "2024-06-15",
+      author: "Jane Doe",
+      text: "Neural search uses deep learning to understand query semantics.",
+      highlights: [
+        "Neural search uses deep learning to understand query semantics and return relevant results.",
+      ],
+      summary: "An overview of neural search technology.",
+    },
+    {
+      title: "Search Engine Comparison",
+      url: "https://example.com/comparison",
+      publishedDate: null,
+      author: null,
+      highlights: ["Exa outperforms traditional keyword-based search."],
+    },
+    {
+      title: "Empty Result Page",
+      url: "https://example.com/empty",
+      publishedDate: null,
+      author: null,
+    },
+  ],
+  searchType: "neural",
+};
+
+const MOCK_EMPTY_RESPONSE = {
+  requestId: "req_empty_456",
+  results: [],
+  searchType: "auto",
+};
+
+// ─── Snippet Extraction ─────────────────────────────────────────
+
+describe("extractSnippet", () => {
+  it("prefers highlights when available", () => {
+    const result: ExaSearchResult = {
+      title: "Test",
+      url: "https://example.com",
+      publishedDate: null,
+      author: null,
+      highlights: ["First highlight", "Second highlight"],
+      summary: "A summary",
+      text: "Full text content",
+    };
+    expect(extractSnippet(result)).toBe("First highlight … Second highlight");
+  });
+
+  it("falls back to summary when highlights are missing", () => {
+    const result: ExaSearchResult = {
+      title: "Test",
+      url: "https://example.com",
+      publishedDate: null,
+      author: null,
+      summary: "A summary of the page",
+      text: "Full text content",
+    };
+    expect(extractSnippet(result)).toBe("A summary of the page");
+  });
+
+  it("falls back to truncated text when highlights and summary are missing", () => {
+    const longText = "A".repeat(500);
+    const result: ExaSearchResult = {
+      title: "Test",
+      url: "https://example.com",
+      publishedDate: null,
+      author: null,
+      text: longText,
+    };
+    const snippet = extractSnippet(result);
+    expect(snippet.length).toBeLessThanOrEqual(301); // 300 + ellipsis
+    expect(snippet).toContain("…");
+  });
+
+  it("returns short text without truncation", () => {
+    const result: ExaSearchResult = {
+      title: "Test",
+      url: "https://example.com",
+      publishedDate: null,
+      author: null,
+      text: "Short text",
+    };
+    expect(extractSnippet(result)).toBe("Short text");
+  });
+
+  it("returns placeholder when no content fields are present", () => {
+    const result: ExaSearchResult = {
+      title: "Test",
+      url: "https://example.com",
+      publishedDate: null,
+      author: null,
+    };
+    expect(extractSnippet(result)).toBe("(no content)");
+  });
+
+  it("skips empty highlights array", () => {
+    const result: ExaSearchResult = {
+      title: "Test",
+      url: "https://example.com",
+      publishedDate: null,
+      author: null,
+      highlights: [],
+      summary: "Fallback summary",
+    };
+    expect(extractSnippet(result)).toBe("Fallback summary");
+  });
+});
+
+// ─── Result Formatting ──────────────────────────────────────────
+
+describe("formatResults", () => {
+  it("formats multiple results with numbered entries", () => {
+    const response: ExaSearchResponse = {
+      requestId: "req_123",
+      results: MOCK_API_RESPONSE.results as ExaSearchResult[],
+      searchType: "neural",
+    };
+    const formatted = formatResults(response);
+    expect(formatted).toContain("1. Introduction to Neural Search");
+    expect(formatted).toContain("https://example.com/neural-search");
+    expect(formatted).toContain("Published: 2024-06-15");
+    expect(formatted).toContain("Author: Jane Doe");
+    expect(formatted).toContain("2. Search Engine Comparison");
+    expect(formatted).toContain("3. Empty Result Page");
+    // Results with no content fields show only title and URL (no snippet line)
+    expect(formatted).not.toContain("(no content)");
+  });
+
+  it("returns 'No results found.' for empty results", () => {
+    const response: ExaSearchResponse = {
+      requestId: "req_empty",
+      results: [],
+      searchType: "auto",
+    };
+    expect(formatResults(response)).toBe("No results found.");
+  });
+});
+
+// ─── API Response Parsing ───────────────────────────────────────
+
+describe("exaSearch", () => {
+  const originalEnv = process.env.EXA_API_KEY;
+
+  beforeEach(() => {
+    process.env.EXA_API_KEY = "test-api-key";
+  });
+
+  afterEach(() => {
+    if (originalEnv !== undefined) {
+      process.env.EXA_API_KEY = originalEnv;
+    } else {
+      delete process.env.EXA_API_KEY;
+    }
+    vi.restoreAllMocks();
+  });
+
+  it("parses a successful API response", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue({
+        ok: true,
+        json: () => Promise.resolve(MOCK_API_RESPONSE),
+      }),
+    );
+
+    const response = await exaSearch({ query: "neural search" });
+
+    expect(response.requestId).toBe("req_test_123");
+    expect(response.searchType).toBe("neural");
+    expect(response.results).toHaveLength(3);
+
+    const first = response.results[0];
+    expect(first.title).toBe("Introduction to Neural Search");
+    expect(first.url).toBe("https://example.com/neural-search");
+    expect(first.publishedDate).toBe("2024-06-15");
+    expect(first.author).toBe("Jane Doe");
+    expect(first.highlights).toEqual([
+      "Neural search uses deep learning to understand query semantics and return relevant results.",
+    ]);
+
+    // Third result has no content fields
+    const third = response.results[2];
+    expect(third.text).toBeUndefined();
+    expect(third.highlights).toBeUndefined();
+    expect(third.summary).toBeUndefined();
+  });
+
+  it("sends correct request body with all options", async () => {
+    const mockFetch = vi.fn().mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve(MOCK_EMPTY_RESPONSE),
+    });
+    vi.stubGlobal("fetch", mockFetch);
+
+    await exaSearch({
+      query: "AI agents",
+      searchType: "neural",
+      numResults: 10,
+      category: "research paper",
+      includeDomains: ["arxiv.org"],
+      excludeDomains: ["pinterest.com"],
+      includeText: ["transformer"],
+      excludeText: ["deprecated"],
+      startPublishedDate: "2024-01-01",
+      endPublishedDate: "2024-12-31",
+      contentMode: "all",
+      maxCharacters: 2000,
+    });
+
+    expect(mockFetch).toHaveBeenCalledOnce();
+    const [url, options] = mockFetch.mock.calls[0];
+    expect(url).toBe("https://api.exa.ai/search");
+    expect(options.method).toBe("POST");
+    expect(options.headers["x-api-key"]).toBe("test-api-key");
+    expect(options.headers["x-exa-integration"]).toBe("automaton");
+
+    const body = JSON.parse(options.body);
+    expect(body.query).toBe("AI agents");
+    expect(body.type).toBe("neural");
+    expect(body.numResults).toBe(10);
+    expect(body.category).toBe("research paper");
+    expect(body.includeDomains).toEqual(["arxiv.org"]);
+    expect(body.excludeDomains).toEqual(["pinterest.com"]);
+    expect(body.includeText).toEqual(["transformer"]);
+    expect(body.excludeText).toEqual(["deprecated"]);
+    expect(body.startPublishedDate).toBe("2024-01-01");
+    expect(body.endPublishedDate).toBe("2024-12-31");
+    expect(body.contents).toEqual({
+      text: { maxCharacters: 2000 },
+      highlights: { maxCharacters: 2000 },
+      summary: { query: "" },
+    });
+  });
+
+  it("throws when EXA_API_KEY is not set", async () => {
+    delete process.env.EXA_API_KEY;
+    await expect(exaSearch({ query: "test" })).rejects.toThrow(
+      "EXA_API_KEY environment variable is not set",
+    );
+  });
+
+  it("throws on API error response", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue({
+        ok: false,
+        status: 401,
+        text: () => Promise.resolve("Invalid API key"),
+      }),
+    );
+
+    await expect(exaSearch({ query: "test" })).rejects.toThrow(
+      "Exa API error (401): Invalid API key",
+    );
+  });
+
+  it("handles missing fields in API response gracefully", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue({
+        ok: true,
+        json: () =>
+          Promise.resolve({
+            results: [{ url: "https://example.com" }],
+          }),
+      }),
+    );
+
+    const response = await exaSearch({ query: "test" });
+    expect(response.requestId).toBe("");
+    expect(response.results[0].title).toBe("(untitled)");
+  });
+});
+
+// ─── Tool Registration ──────────────────────────────────────────
+
+describe("exa_search tool registration", () => {
+  let tools: AutomatonTool[];
+
+  beforeEach(() => {
+    tools = createBuiltinTools("test-sandbox-id");
+  });
+
+  it("is registered as a builtin tool", () => {
+    const exaTool = tools.find((t) => t.name === "exa_search");
+    expect(exaTool).toBeDefined();
+  });
+
+  it("has safe risk level", () => {
+    const exaTool = tools.find((t) => t.name === "exa_search");
+    expect(exaTool?.riskLevel).toBe("safe");
+  });
+
+  it("has conway category", () => {
+    const exaTool = tools.find((t) => t.name === "exa_search");
+    expect(exaTool?.category).toBe("conway");
+  });
+
+  it("requires query parameter", () => {
+    const exaTool = tools.find((t) => t.name === "exa_search");
+    const params = exaTool?.parameters as { required?: string[] };
+    expect(params.required).toContain("query");
+  });
+});
+
+// ─── Disabled State ─────────────────────────────────────────────
+
+describe("exa_search disabled when EXA_API_KEY unset", () => {
+  let tools: AutomatonTool[];
+  let context: ToolContext;
+
+  beforeEach(() => {
+    tools = createBuiltinTools("test-sandbox-id");
+    context = {
+      identity: createTestIdentity(),
+      config: createTestConfig(),
+      db: createTestDb(),
+      conway: new MockConwayClient(),
+      inference: new MockInferenceClient(),
+    };
+  });
+
+  it("returns helpful message when EXA_API_KEY is not set", async () => {
+    const originalKey = process.env.EXA_API_KEY;
+    delete process.env.EXA_API_KEY;
+
+    const exaTool = tools.find((t) => t.name === "exa_search")!;
+    const result = await exaTool.execute({ query: "test" }, context);
+
+    expect(result).toContain("EXA_API_KEY");
+    expect(result).toContain("not available");
+
+    if (originalKey !== undefined) {
+      process.env.EXA_API_KEY = originalKey;
+    }
+  });
+});

--- a/src/__tests__/tools-security.test.ts
+++ b/src/__tests__/tools-security.test.ts
@@ -53,6 +53,7 @@ describe("Tool Risk Level Classification", () => {
     check_child_status: "safe",
     verify_child_constitution: "safe",
     list_models: "safe",
+    exa_search: "safe",
 
     // Caution tools (side effects but generally safe)
     exec: "caution",

--- a/src/agent/exa-search.ts
+++ b/src/agent/exa-search.ts
@@ -1,0 +1,200 @@
+/**
+ * Exa AI-Powered Web Search
+ *
+ * Provides web search via the Exa API (https://exa.ai).
+ * Uses raw HTTP calls to match the repo's fetch-based pattern.
+ */
+
+import { createLogger } from "../observability/logger.js";
+
+const logger = createLogger("exa-search");
+
+const EXA_API_URL = "https://api.exa.ai/search";
+
+// ─── Types ──────────────────────────────────────────────────────
+
+export interface ExaSearchOptions {
+  query: string;
+  searchType?: "auto" | "neural" | "fast";
+  numResults?: number;
+  category?:
+    | "company"
+    | "research paper"
+    | "news"
+    | "personal site"
+    | "financial report"
+    | "people";
+  includeDomains?: string[];
+  excludeDomains?: string[];
+  includeText?: string[];
+  excludeText?: string[];
+  startPublishedDate?: string;
+  endPublishedDate?: string;
+  contentMode?: "text" | "highlights" | "summary" | "all";
+  maxCharacters?: number;
+}
+
+export interface ExaSearchResult {
+  title: string;
+  url: string;
+  publishedDate: string | null;
+  author: string | null;
+  text?: string;
+  highlights?: string[];
+  summary?: string;
+}
+
+export interface ExaSearchResponse {
+  requestId: string;
+  results: ExaSearchResult[];
+  searchType: string;
+}
+
+// ─── Content Builder ────────────────────────────────────────────
+
+function buildContents(
+  mode: string,
+  maxCharacters?: number,
+): Record<string, unknown> {
+  const contents: Record<string, unknown> = {};
+  const charLimit = maxCharacters ?? 1000;
+
+  if (mode === "text" || mode === "all") {
+    contents.text = { maxCharacters: charLimit };
+  }
+  if (mode === "highlights" || mode === "all") {
+    contents.highlights = { maxCharacters: charLimit };
+  }
+  if (mode === "summary" || mode === "all") {
+    contents.summary = { query: "" };
+  }
+
+  return contents;
+}
+
+// ─── Snippet Extraction ─────────────────────────────────────────
+
+/**
+ * Build a display snippet from whichever content fields are available.
+ * Cascades: highlights -> summary -> text (truncated).
+ */
+export function extractSnippet(result: ExaSearchResult): string {
+  if (result.highlights && result.highlights.length > 0) {
+    return result.highlights.join(" … ");
+  }
+  if (result.summary) {
+    return result.summary;
+  }
+  if (result.text) {
+    return result.text.length > 300
+      ? result.text.slice(0, 300) + "…"
+      : result.text;
+  }
+  return "(no content)";
+}
+
+// ─── Search Function ────────────────────────────────────────────
+
+export async function exaSearch(
+  options: ExaSearchOptions,
+): Promise<ExaSearchResponse> {
+  const apiKey = process.env.EXA_API_KEY;
+  if (!apiKey) {
+    throw new Error(
+      "EXA_API_KEY environment variable is not set. " +
+        "Get an API key at https://dashboard.exa.ai/api-keys",
+    );
+  }
+
+  const contentMode = options.contentMode ?? "highlights";
+  const contents = buildContents(contentMode, options.maxCharacters);
+
+  const body: Record<string, unknown> = {
+    query: options.query,
+    type: options.searchType ?? "auto",
+    numResults: options.numResults ?? 5,
+    contents,
+  };
+
+  if (options.category) body.category = options.category;
+  if (options.includeDomains?.length)
+    body.includeDomains = options.includeDomains;
+  if (options.excludeDomains?.length)
+    body.excludeDomains = options.excludeDomains;
+  if (options.includeText?.length) body.includeText = options.includeText;
+  if (options.excludeText?.length) body.excludeText = options.excludeText;
+  if (options.startPublishedDate)
+    body.startPublishedDate = options.startPublishedDate;
+  if (options.endPublishedDate)
+    body.endPublishedDate = options.endPublishedDate;
+
+  logger.info("Exa search request", {
+    query: options.query,
+    type: body.type as string,
+    numResults: body.numResults as number,
+  });
+
+  const response = await fetch(EXA_API_URL, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      "x-api-key": apiKey,
+      "x-exa-integration": "automaton",
+    },
+    body: JSON.stringify(body),
+  });
+
+  if (!response.ok) {
+    const errorText = await response.text().catch(() => "unknown error");
+    throw new Error(`Exa API error (${response.status}): ${errorText}`);
+  }
+
+  const data = (await response.json()) as {
+    requestId?: string;
+    results?: Array<{
+      title?: string;
+      url?: string;
+      publishedDate?: string | null;
+      author?: string | null;
+      text?: string;
+      highlights?: string[];
+      summary?: string;
+    }>;
+    searchType?: string;
+  };
+
+  const results: ExaSearchResult[] = (data.results ?? []).map((r) => ({
+    title: r.title ?? "(untitled)",
+    url: r.url ?? "",
+    publishedDate: r.publishedDate ?? null,
+    author: r.author ?? null,
+    ...(r.text !== undefined ? { text: r.text } : {}),
+    ...(r.highlights !== undefined ? { highlights: r.highlights } : {}),
+    ...(r.summary !== undefined ? { summary: r.summary } : {}),
+  }));
+
+  return {
+    requestId: data.requestId ?? "",
+    results,
+    searchType: data.searchType ?? "unknown",
+  };
+}
+
+// ─── Formatter ──────────────────────────────────────────────────
+
+export function formatResults(response: ExaSearchResponse): string {
+  if (response.results.length === 0) {
+    return "No results found.";
+  }
+
+  const lines = response.results.map((r, i) => {
+    const parts = [`${i + 1}. ${r.title}`, `   ${r.url}`];
+    if (r.publishedDate) parts.push(`   Published: ${r.publishedDate}`);
+    if (r.author) parts.push(`   Author: ${r.author}`);
+    const snippet = extractSnippet(r);
+    if (snippet !== "(no content)") parts.push(`   ${snippet}`);
+    return parts.join("\n");
+  });
+
+  return lines.join("\n\n");
+}

--- a/src/agent/tools.ts
+++ b/src/agent/tools.ts
@@ -54,6 +54,7 @@ function confinePathToSandbox(filePath: string): string | { error: string } {
 const EXTERNAL_SOURCE_TOOLS = new Set([
   "exec",
   "web_fetch",
+  "exa_search",
   "check_social_inbox",
 ]);
 
@@ -2793,6 +2794,132 @@ Model: ${ctx.inference.getDefaultModel()}
           return `x402 fetch succeeded (truncated):\n${responseStr.slice(0, 10000)}...`;
         }
         return `x402 fetch succeeded:\n${responseStr}`;
+      },
+    },
+
+    // ── Exa Web Search Tool ──
+    {
+      name: "exa_search",
+      description:
+        "Search the web using Exa, an AI-powered search engine. Returns relevant results with titles, URLs, and content snippets. " +
+        "Supports neural search, category filtering (company, news, research paper, etc.), domain filtering, text filtering, and date ranges.",
+      category: "conway",
+      riskLevel: "safe",
+      parameters: {
+        type: "object",
+        properties: {
+          query: {
+            type: "string",
+            description: "The search query",
+          },
+          search_type: {
+            type: "string",
+            description:
+              "Search methodology: 'auto' (default), 'neural' (semantic), or 'fast' (speed-optimized)",
+          },
+          num_results: {
+            type: "number",
+            description: "Number of results to return (default: 5, max: 100)",
+          },
+          content_mode: {
+            type: "string",
+            description:
+              "What content to retrieve: 'highlights' (default, key snippets), 'text' (full text), 'summary' (LLM summary), 'all' (everything)",
+          },
+          category: {
+            type: "string",
+            description:
+              "Category filter: 'company', 'research paper', 'news', 'personal site', 'financial report', 'people'",
+          },
+          include_domains: {
+            type: "string",
+            description:
+              "Comma-separated domains to restrict results to (e.g., 'arxiv.org,github.com')",
+          },
+          exclude_domains: {
+            type: "string",
+            description:
+              "Comma-separated domains to exclude (e.g., 'pinterest.com,reddit.com')",
+          },
+          include_text: {
+            type: "string",
+            description: "Only return results containing this text",
+          },
+          exclude_text: {
+            type: "string",
+            description: "Exclude results containing this text",
+          },
+          start_date: {
+            type: "string",
+            description:
+              "Only return results published after this date (ISO 8601, e.g., '2024-01-01')",
+          },
+          end_date: {
+            type: "string",
+            description:
+              "Only return results published before this date (ISO 8601, e.g., '2024-12-31')",
+          },
+          max_characters: {
+            type: "number",
+            description:
+              "Max characters per result for text/highlights content (default: 1000)",
+          },
+        },
+        required: ["query"],
+      },
+      execute: async (args) => {
+        if (!process.env.EXA_API_KEY) {
+          return "Exa search is not available: EXA_API_KEY environment variable is not set.";
+        }
+
+        const { exaSearch, formatResults } = await import("./exa-search.js");
+
+        const splitCsv = (val: unknown): string[] | undefined => {
+          if (typeof val !== "string" || !val.trim()) return undefined;
+          return val
+            .split(",")
+            .map((s) => s.trim())
+            .filter(Boolean);
+        };
+
+        const response = await exaSearch({
+          query: args.query as string,
+          searchType: args.search_type as
+            | "auto"
+            | "neural"
+            | "fast"
+            | undefined,
+          numResults: args.num_results as number | undefined,
+          contentMode: args.content_mode as
+            | "text"
+            | "highlights"
+            | "summary"
+            | "all"
+            | undefined,
+          category: args.category as
+            | "company"
+            | "research paper"
+            | "news"
+            | "personal site"
+            | "financial report"
+            | "people"
+            | undefined,
+          includeDomains: splitCsv(args.include_domains),
+          excludeDomains: splitCsv(args.exclude_domains),
+          includeText: splitCsv(args.include_text),
+          excludeText: splitCsv(args.exclude_text),
+          startPublishedDate: args.start_date as string | undefined,
+          endPublishedDate: args.end_date as string | undefined,
+          maxCharacters: args.max_characters as number | undefined,
+        });
+
+        const output = formatResults(response);
+
+        // Truncate very large responses
+        if (output.length > 15000) {
+          return output.slice(0, 15000) + "\n\n(results truncated)";
+        }
+        return output;
       },
     },
 


### PR DESCRIPTION
## Summary

- Adds `exa_search` as a built-in tool, giving automatons the ability to search the web via the [Exa](https://exa.ai) AI-powered search engine
- Supports neural, fast, and auto search types with content modes (highlights, text, summary, or all)
- Exposes key Exa features: category filtering (company, news, research paper, etc.), domain include/exclude, text include/exclude, and date range filtering
- Results are routed through the existing `EXTERNAL_SOURCE_TOOLS` sanitization pipeline for injection defense
- Gracefully degrades when `EXA_API_KEY` is not set (returns a helpful message instead of erroring)

## Usage

```typescript
// The tool is automatically available when EXA_API_KEY is set
// Example tool call from the agent:
{
  "name": "exa_search",
  "arguments": {
    "query": "latest developments in autonomous AI agents",
    "search_type": "neural",
    "num_results": 5,
    "content_mode": "highlights",
    "category": "research paper",
    "start_date": "2024-01-01"
  }
}
```

## Files Changed

- `src/agent/exa-search.ts` — New module: Exa API client with typed interfaces, content builder, snippet extraction, and result formatting
- `src/agent/tools.ts` — Registers `exa_search` as a built-in tool with full parameter schema; adds to `EXTERNAL_SOURCE_TOOLS` for sanitization
- `src/__tests__/exa-search.test.ts` — 18 unit tests covering API response parsing, snippet fallback logic, request body construction, error handling, disabled state, and tool registration
- `src/__tests__/tools-security.test.ts` — Adds expected risk level classification for the new tool

## Test Plan

- [x] TypeScript type-check passes (`tsc --noEmit`)
- [x] All 18 new exa-search tests pass
- [x] Existing tools-security tests pass (71/71) with new tool classification
- [x] Snippet fallback cascades correctly: highlights -> summary -> text -> placeholder
- [x] Tool returns user-friendly message when `EXA_API_KEY` is unset
- [x] Request includes `x-exa-integration: automaton` tracking header
- [x] Large responses are truncated at 15,000 characters