### PR TITLE
feat(skills): add MiniMax-AI/cli as default skill tap

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,10 @@ The only path to survival is honest work that others voluntarily pay for.
 
 ## Skills (New, WIP)
 
-To help save Automatons Tokens & simplify setup of permissionless services & capabilities, we introduce Conway Automaton Skills ( [Conway-Research/skills](https://github.com/Conway-Research/skills) ). We are open to contributions to make Automatons more capable. 
+To help save Automatons Tokens & simplify setup of permissionless services & capabilities, we introduce Conway Automaton Skills ( [Conway-Research/skills](https://github.com/Conway-Research/skills) ). We are open to contributions to make Automatons more capable.
+
+Available community skills:
+- [mmx-cli](https://github.com/MiniMax-AI/cli) — Generate text, images, video, speech, and music via MiniMax AI (`install_skill` with `source: "git"`, `url: "https://github.com/MiniMax-AI/cli"`, `name: "mmx-cli"`)
 
 ## Self-Modification
 


### PR DESCRIPTION
## Summary

- Add `MiniMax-AI/cli` to the **Skills** section of README.md so the mmx-cli skill is discoverable out of the box
- Users can install via `install_skill` with `source: "git"`, `url: "https://github.com/MiniMax-AI/cli"`, `name: "mmx-cli"` — the SKILL.md is fetched directly from [MiniMax-AI/cli](https://github.com/MiniMax-AI/cli/blob/main/skill/SKILL.md)
- Skill updates are fully decoupled: MiniMax maintains the upstream SKILL.md, no changes needed in this project

**4 lines changed (+4, -1), 0 new files.**

## What is mmx-cli?

[mmx-cli](https://github.com/MiniMax-AI/cli) is a CLI tool for the MiniMax AI platform, providing:
- **Text generation** (MiniMax-M2.7 model)
- **Image generation** (image-01)
- **Video generation** (Hailuo-2.3)
- **Speech synthesis** (speech-2.8-hd, 300+ voices)
- **Music generation** (music-2.6, with lyrics, cover, and instrumental)
- **Web search**

The [SKILL.md](https://github.com/MiniMax-AI/cli/blob/main/skill/SKILL.md) follows the [agentskills.io](https://agentskills.io) standard and includes agent-specific flags (`--non-interactive`, `--quiet`, `--output json`).

## Test plan

- Automaton agent running `install_skill` with the provided `git` source successfully installs mmx-cli
- `list_skills` shows the mmx-cli skill after installation
- Ask agent "generate a jazz instrumental" — agent invokes `mmx music generate` via terminal