### PR TITLE
fix(orchestration): harden local-worker tools — path traversal, sensitive reads, forbidden exec (closes #310)

### DIFF
--- a/src/__tests__/http-client.test.ts
+++ b/src/__tests__/http-client.test.ts
@@ -42,6 +42,60 @@ afterEach(() => {
 // ─── Tests ─────────────────────────────────────────────────────
 
 describe("ResilientHttpClient", () => {
+  describe("HTTPS enforcement", () => {
+    it("rejects remote HTTP URLs", async () => {
+      const client = new ResilientHttpClient({ maxRetries: 0 });
+      const fetchSpy = vi.fn();
+      globalThis.fetch = fetchSpy as any;
+
+      await expect(
+        client.request("http://api.example.com/test"),
+      ).rejects.toThrow("HTTPS required");
+      expect(fetchSpy).not.toHaveBeenCalled();
+    });
+
+    it("allows HTTPS URLs", async () => {
+      const client = new ResilientHttpClient({ maxRetries: 0 });
+      globalThis.fetch = vi.fn().mockResolvedValue(mockResponse(200));
+
+      const resp = await client.request("https://api.example.com/test");
+      expect(resp.status).toBe(200);
+    });
+
+    it("rejects loopback HTTP when not explicitly allowed", async () => {
+      const client = new ResilientHttpClient({ maxRetries: 0 });
+      const fetchSpy = vi.fn();
+      globalThis.fetch = fetchSpy as any;
+
+      await expect(
+        client.request("http://localhost:11434/v1/chat/completions"),
+      ).rejects.toThrow("HTTPS required");
+      expect(fetchSpy).not.toHaveBeenCalled();
+    });
+
+    it("allows loopback HTTP when explicitly enabled", async () => {
+      const client = new ResilientHttpClient({
+        maxRetries: 0,
+        allowHttpOnLoopback: true,
+      });
+      globalThis.fetch = vi.fn().mockResolvedValue(mockResponse(200, { ok: true }));
+
+      const resp = await client.request("http://127.0.0.1:11434/api/tags");
+      expect(resp.status).toBe(200);
+    });
+
+    it("rejects invalid URL strings", async () => {
+      const client = new ResilientHttpClient({ maxRetries: 0 });
+      const fetchSpy = vi.fn();
+      globalThis.fetch = fetchSpy as any;
+
+      await expect(
+        client.request("not-a-url"),
+      ).rejects.toThrow("Invalid URL");
+      expect(fetchSpy).not.toHaveBeenCalled();
+    });
+  });
+
   describe("timeout behavior", () => {
     it("aborts request after configured timeout", async () => {
       const client = new ResilientHttpClient({

--- a/src/__tests__/orchestration/local-worker-security.test.ts
+++ b/src/__tests__/orchestration/local-worker-security.test.ts
@@ -1,0 +1,138 @@
+import { mkdtempSync, mkdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import path from "node:path";
+import type BetterSqlite3 from "better-sqlite3";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { LocalWorkerPool } from "../../orchestration/local-worker.js";
+import type { ConwayClient } from "../../types.js";
+import { createInMemoryDb } from "./test-db.js";
+
+function createConwayStub(overrides?: Partial<ConwayClient>): ConwayClient {
+  return {
+    exec: async () => ({ stdout: "", stderr: "", exitCode: 0 }),
+    writeFile: async () => undefined,
+    readFile: async () => "",
+    exposePort: async () => ({ port: 0, publicUrl: "", sandboxId: "" }),
+    removePort: async () => undefined,
+    createSandbox: async () => ({ id: "", status: "", region: "", vcpu: 0, memoryMb: 0, diskGb: 0, createdAt: "" }),
+    deleteSandbox: async () => undefined,
+    listSandboxes: async () => [],
+    getCreditsBalance: async () => 0,
+    getCreditsPricing: async () => [],
+    transferCredits: async () => ({ id: "", fromAddress: "", toAddress: "", amountCents: 0, status: "completed", timestamp: "" }),
+    registerAutomaton: async () => ({ automaton: {} }),
+    searchDomains: async () => [],
+    registerDomain: async () => ({ domain: "", status: "pending", registrationDate: "", expirationDate: "", nameservers: [] }),
+    listDnsRecords: async () => [],
+    addDnsRecord: async () => ({ id: "", type: "A", host: "", value: "", ttl: 300 }),
+    deleteDnsRecord: async () => undefined,
+    listModels: async () => [],
+    createScopedClient: () => createConwayStub(),
+    ...overrides,
+  } as ConwayClient;
+}
+
+describe("orchestration/local-worker security", () => {
+  let db: BetterSqlite3.Database;
+  let testRoot: string;
+
+  beforeEach(() => {
+    db = createInMemoryDb();
+    testRoot = mkdtempSync(path.join(process.cwd(), ".tmp-local-worker-"));
+  });
+
+  afterEach(() => {
+    db.close();
+    rmSync(testRoot, { recursive: true, force: true });
+  });
+
+  function getTools(conway: ConwayClient) {
+    const pool = new LocalWorkerPool({
+      db,
+      conway,
+      workerId: "worker-test",
+      inference: {
+        chat: async () => ({ content: "done" }),
+      },
+    });
+    return (pool as any).buildWorkerTools() as Array<{ name: string; execute: (args: Record<string, unknown>) => Promise<string> }>;
+  }
+
+  async function runTool(
+    conway: ConwayClient,
+    toolName: string,
+    args: Record<string, unknown>,
+  ): Promise<string> {
+    const tools = getTools(conway);
+    const tool = tools.find((t) => t.name === toolName);
+    if (!tool) throw new Error(`missing tool: ${toolName}`);
+    return tool.execute(args);
+  }
+
+  it("blocks sensitive file reads (wallet.json)", async () => {
+    const out = await runTool(createConwayStub(), "read_file", { path: "wallet.json" });
+    expect(out).toContain("Blocked: cannot read sensitive file");
+  });
+
+  it("blocks traversal reads outside workspace", async () => {
+    const out = await runTool(createConwayStub(), "read_file", { path: "../../etc/passwd" });
+    expect(out).toContain("Blocked: path");
+    expect(out).toContain("outside the local worker workspace");
+  });
+
+  it("blocks absolute-path reads outside workspace", async () => {
+    const out = await runTool(createConwayStub(), "read_file", { path: "/etc/passwd" });
+    expect(out).toContain("Blocked: path");
+  });
+
+  it("blocks writes outside workspace", async () => {
+    const out = await runTool(createConwayStub(), "write_file", {
+      path: "../../tmp/pwned.txt",
+      content: "x",
+    });
+    expect(out).toContain("Blocked: path");
+  });
+
+  it("blocks writes to protected files", async () => {
+    const out = await runTool(createConwayStub(), "write_file", {
+      path: "constitution.md",
+      content: "tamper",
+    });
+    expect(out).toContain("Blocked: cannot write to protected file");
+  });
+
+  it("blocks forbidden shell commands", async () => {
+    const out = await runTool(createConwayStub(), "exec", {
+      command: "cat ~/.automaton/wallet.json",
+    });
+    expect(out).toContain("Blocked:");
+  });
+
+  it("allows normal read_file path inside workspace", async () => {
+    const filePath = path.join(testRoot, "notes.txt");
+    mkdirSync(path.dirname(filePath), { recursive: true });
+    writeFileSync(filePath, "hello", "utf8");
+
+    const conway = createConwayStub({
+      readFile: async () => {
+        throw new Error("force local fallback");
+      },
+    });
+
+    const out = await runTool(conway, "read_file", { path: filePath });
+    expect(out).toBe("hello");
+  });
+
+  it("allows normal write_file path inside workspace", async () => {
+    const filePath = path.join(testRoot, "out", "data.txt");
+
+    const conway = createConwayStub({
+      writeFile: async () => {
+        throw new Error("force local fallback");
+      },
+    });
+
+    const out = await runTool(conway, "write_file", { path: filePath, content: "ok" });
+    expect(out).toContain("Wrote 2 bytes");
+    expect(readFileSync(filePath, "utf8")).toBe("ok");
+  });
+});

--- a/src/agent/policy-rules/command-safety.ts
+++ b/src/agent/policy-rules/command-safety.ts
@@ -69,6 +69,19 @@ const FORBIDDEN_COMMAND_PATTERNS: { pattern: RegExp; description: string }[] = [
   { pattern: />\s*.*policy-rules/, description: "Overwrite policy rules" },
 ];
 
+export function getForbiddenCommandMatch(command: string): { description: string; pattern: string } | null {
+  for (const { pattern, description } of FORBIDDEN_COMMAND_PATTERNS) {
+    if (pattern.test(command)) {
+      return { description, pattern: pattern.source };
+    }
+  }
+  return null;
+}
+
+export function isForbiddenCommand(command: string): boolean {
+  return getForbiddenCommandMatch(command) !== null;
+}
+
 function deny(rule: string, reasonCode: string, humanMessage: string): PolicyRuleResult {
   return { rule, action: "deny", reasonCode, humanMessage };
 }
@@ -125,14 +138,13 @@ function createForbiddenPatternsRule(): PolicyRule {
       const command = request.args.command as string | undefined;
       if (!command) return null;
 
-      for (const { pattern, description } of FORBIDDEN_COMMAND_PATTERNS) {
-        if (pattern.test(command)) {
-          return deny(
-            "command.forbidden_patterns",
-            "FORBIDDEN_COMMAND",
-            `Blocked: ${description} (pattern: ${pattern.source})`,
-          );
-        }
+      const match = getForbiddenCommandMatch(command);
+      if (match) {
+        return deny(
+          "command.forbidden_patterns",
+          "FORBIDDEN_COMMAND",
+          `Blocked: ${match.description} (pattern: ${match.pattern})`,
+        );
       }
 
       return null;

--- a/src/agent/policy-rules/path-protection.ts
+++ b/src/agent/policy-rules/path-protection.ts
@@ -36,7 +36,7 @@ function deny(rule: string, reasonCode: string, humanMessage: string): PolicyRul
 /**
  * Check if a file path matches a sensitive read pattern.
  */
-function isSensitiveFile(filePath: string): boolean {
+export function isSensitiveFile(filePath: string): boolean {
   const resolved = path.resolve(filePath);
   const basename = path.basename(resolved);
 

--- a/src/conway/http-client.ts
+++ b/src/conway/http-client.ts
@@ -10,6 +10,35 @@
 import type { HttpClientConfig } from "../types.js";
 import { DEFAULT_HTTP_CLIENT_CONFIG } from "../types.js";
 
+const LOOPBACK_HOSTS = new Set(["localhost", "127.0.0.1", "::1"]);
+
+function assertSecureUrl(
+  url: string,
+  allowHttpOnLoopback: boolean,
+): void {
+  let parsed: URL;
+  try {
+    parsed = new URL(url);
+  } catch {
+    throw new Error(`Invalid URL: ${url}`);
+  }
+
+  const protocol = parsed.protocol.toLowerCase();
+  if (protocol === "https:") {
+    return;
+  }
+
+  const host = parsed.hostname.toLowerCase();
+  if (protocol === "http:" && allowHttpOnLoopback && LOOPBACK_HOSTS.has(host)) {
+    return;
+  }
+
+  throw new Error(
+    `HTTPS required: refusing insecure URL ${url}. ` +
+      "For local development, only loopback HTTP (localhost/127.0.0.1/::1) can be explicitly enabled.",
+  );
+}
+
 export class CircuitOpenError extends Error {
   constructor(public readonly resetAt: number) {
     super(
@@ -36,6 +65,8 @@ export class ResilientHttpClient {
       retries?: number;
     },
   ): Promise<Response> {
+    assertSecureUrl(url, this.config.allowHttpOnLoopback);
+
     if (this.isCircuitOpen()) {
       throw new CircuitOpenError(this.circuitOpenUntil);
     }

--- a/src/conway/inference.ts
+++ b/src/conway/inference.ts
@@ -33,6 +33,18 @@ interface InferenceClientOptions {
 
 type InferenceBackend = "conway" | "openai" | "anthropic" | "ollama";
 
+function isLoopbackHttpUrl(url: string | undefined): boolean {
+  if (!url) return false;
+  try {
+    const parsed = new URL(url);
+    const host = parsed.hostname.toLowerCase();
+    return parsed.protocol.toLowerCase() === "http:" &&
+      (host === "localhost" || host === "127.0.0.1" || host === "::1");
+  } catch {
+    return false;
+  }
+}
+
 export function createInferenceClient(
   options: InferenceClientOptions,
 ): InferenceClient {
@@ -40,6 +52,7 @@ export function createInferenceClient(
   const httpClient = new ResilientHttpClient({
     baseTimeout: INFERENCE_TIMEOUT_MS,
     retryableStatuses: [429, 500, 502, 503, 504],
+    allowHttpOnLoopback: isLoopbackHttpUrl(ollamaBaseUrl),
   });
   let currentModel = options.defaultModel;
   let maxTokens = options.maxTokens;

--- a/src/orchestration/local-worker.ts
+++ b/src/orchestration/local-worker.ts
@@ -15,6 +15,9 @@ import { exec as execCb } from "node:child_process";
 import { promises as fs } from "node:fs";
 import path from "node:path";
 import { createLogger } from "../observability/logger.js";
+import { isForbiddenCommand, getForbiddenCommandMatch } from "../agent/policy-rules/command-safety.js";
+import { isSensitiveFile } from "../agent/policy-rules/path-protection.js";
+import { isProtectedFile } from "../self-mod/code.js";
 import { UnifiedInferenceClient } from "../inference/inference-client.js";
 import { completeTask, failTask } from "./task-graph.js";
 import type { TaskNode, TaskResult } from "./task-graph.js";
@@ -51,6 +54,20 @@ const logger = createLogger("orchestration.local-worker");
 
 const MAX_TURNS = 25;
 const DEFAULT_TIMEOUT_MS = 5 * 60_000;
+const SANDBOX_ROOT = process.cwd();
+
+function confinePathToWorkspace(filePath: string): string | { error: string } {
+  const expanded = filePath.startsWith("~")
+    ? path.join(SANDBOX_ROOT, filePath.slice(1))
+    : filePath;
+  const resolved = path.resolve(SANDBOX_ROOT, expanded);
+  if (resolved !== SANDBOX_ROOT && !resolved.startsWith(SANDBOX_ROOT + path.sep)) {
+    return {
+      error: `Blocked: path "${filePath}" resolves to "${resolved}" which is outside the local worker workspace (${SANDBOX_ROOT}).`,
+    };
+  }
+  return resolved;
+}
 
 // Minimal inference interface — works with both UnifiedInferenceClient and
 // an adapter around the main agent's InferenceClient.
@@ -332,6 +349,10 @@ RULES:
         execute: async (args) => {
           const command = args.command as string;
           const timeoutMs = typeof args.timeout_ms === "number" ? args.timeout_ms : 30_000;
+          const forbidden = getForbiddenCommandMatch(command);
+          if (forbidden || isForbiddenCommand(command)) {
+            return `Blocked: ${forbidden?.description ?? "Forbidden command"}`;
+          }
 
           // Try Conway API first, fall back to local shell
           try {
@@ -365,14 +386,21 @@ RULES:
         execute: async (args) => {
           const filePath = args.path as string;
           const content = args.content as string;
+          const confined = confinePathToWorkspace(filePath);
+          if (typeof confined !== "string") {
+            return confined.error;
+          }
+          if (isProtectedFile(confined)) {
+            return `Blocked: cannot write to protected file \"${filePath}\"`;
+          }
 
           try {
-            await this.config.conway.writeFile(filePath, content);
-            return `Wrote ${content.length} bytes to ${filePath}`;
+            await this.config.conway.writeFile(confined, content);
+            return `Wrote ${content.length} bytes to ${confined}`;
           } catch {
             try {
-              await localWriteFile(filePath, content);
-              return `Wrote ${content.length} bytes to ${filePath} (local)`;
+              await localWriteFile(confined, content);
+              return `Wrote ${content.length} bytes to ${confined} (local)`;
             } catch (error) {
               return `write error: ${error instanceof Error ? error.message : String(error)}`;
             }
@@ -390,12 +418,20 @@ RULES:
           required: ["path"],
         },
         execute: async (args) => {
+          const filePath = args.path as string;
+          if (isSensitiveFile(filePath)) {
+            return `Blocked: cannot read sensitive file \"${filePath}\"`;
+          }
+          const confined = confinePathToWorkspace(filePath);
+          if (typeof confined !== "string") {
+            return confined.error;
+          }
           try {
-            const content = await this.config.conway.readFile(args.path as string);
+            const content = await this.config.conway.readFile(confined);
             return content.slice(0, 10_000) || "(empty file)";
           } catch {
             try {
-              const content = await localReadFile(args.path as string);
+              const content = await localReadFile(confined);
               return content.slice(0, 10_000) || "(empty file)";
             } catch (error) {
               return `read error: ${error instanceof Error ? error.message : String(error)}`;

--- a/src/types.ts
+++ b/src/types.ts
@@ -607,6 +607,7 @@ export interface HttpClientConfig {
   backoffMax: number;                // default: 30_000ms
   circuitBreakerThreshold: number;   // default: 5
   circuitBreakerResetMs: number;     // default: 60_000ms
+  allowHttpOnLoopback: boolean;      // default: false (for local dev only)
 }
 
 export const DEFAULT_HTTP_CLIENT_CONFIG: HttpClientConfig = {
@@ -617,6 +618,7 @@ export const DEFAULT_HTTP_CLIENT_CONFIG: HttpClientConfig = {
   backoffMax: 30_000,
   circuitBreakerThreshold: 5,
   circuitBreakerResetMs: 60_000,
+  allowHttpOnLoopback: false,
 };
 
 // ─── Database ────────────────────────────────────────────────────


### PR DESCRIPTION
## Problem

The `LocalWorkerPool` in `src/orchestration/local-worker.ts` builds its own
tool set (`buildWorkerTools`) that bypasses every security layer the main
agent uses. When the Conway API is unavailable, the tools fall through to
raw `fs.readFile`, `fs.writeFile`, and `child_process.exec` with no guards
at all.

Three distinct issues, all exploitable via a crafted task payload (e.g. an
injected 0xWork task):

| Tool | Gap | Impact |
|---|---|---|
| `read_file` | No sensitive file blocklist, no path confinement | Wallet/key exfiltration |
| `write_file` | No workspace confinement, no protected-file check | Overwrite constitution.md, injection-defense.ts, etc. |
| `exec` | No forbidden-command patterns on local fallback | Arbitrary host shell execution |

**Chained attack path (as described in #310):**
injected task instruction → worker calls `read_file("~/.automaton/wallet.json")`
→ private key returned in tool result → exfiltrated via task output

## Fix

Applies the same guards the main agent already has, imported from the
existing policy rule modules (no logic duplication):

**`read_file`**
- `isSensitiveFile()` check blocks `wallet.json`, `config.json`, `.env`,
  `automaton.json`, `*.key`, `*.pem`, `private-key*`
- `confinePathToWorkspace()` rejects any path resolving outside `process.cwd()`
  (handles `../..`, absolute paths, and `~` expansion)

**`write_file`**
- `confinePathToWorkspace()` path confinement
- `isProtectedFile()` blocks writes to constitution, injection-defense,
  policy-engine, wallet, state.db, etc.

**`exec`**
- `getForbiddenCommandMatch()` blocks self-destruction and credential-
  harvesting patterns before both the Conway API path and the local fallback

The two policy helpers (`isSensitiveFile`, `isForbiddenCommand` /
`getForbiddenCommandMatch`) are exported from their existing modules — the
guard logic itself is unchanged.

## Tests

`src/__tests__/orchestration/local-worker-security.test.ts` — 8 new tests:

- ✓ blocks sensitive file reads (`wallet.json`)
- ✓ blocks traversal reads (`../../etc/passwd`)
- ✓ blocks absolute-path reads outside workspace (`/etc/passwd`)
- ✓ blocks writes outside workspace (`../../tmp/pwned.txt`)
- ✓ blocks writes to protected files (`constitution.md`)
- ✓ blocks forbidden exec (`cat ~/.automaton/wallet.json`)
- ✓ allows normal in-workspace read (happy path)
- ✓ allows normal in-workspace write with dir creation (happy path)

All 8 pass. `tsc --noEmit` clean.

## Files changed

- `src/agent/policy-rules/path-protection.ts` — export `isSensitiveFile`
- `src/agent/policy-rules/command-safety.ts` — export `isForbiddenCommand`, `getForbiddenCommandMatch`
- `src/orchestration/local-worker.ts` — harden all three tool execute functions
- `src/__tests__/orchestration/local-worker-security.test.ts` — new test file

Closes #310