### PR TITLE
cli: validate logs tail argument

### DIFF
--- a/packages/cli/src/commands/logs.ts
+++ b/packages/cli/src/commands/logs.ts
@@ -13,8 +13,13 @@ const accent = chalk.rgb(131, 127, 255);
 const args = process.argv.slice(3);
 let limit = 20;
 const tailIdx = args.indexOf("--tail");
-if (tailIdx !== -1 && args[tailIdx + 1]) {
-  limit = parseInt(args[tailIdx + 1], 10) || 20;
+if (tailIdx !== -1) {
+  const rawLimit = args[tailIdx + 1];
+  if (!rawLimit || !/^\d+$/.test(rawLimit) || Number(rawLimit) < 1) {
+    console.log(chalk.red("Invalid --tail value. Expected a positive integer."));
+    process.exit(1);
+  }
+  limit = Number(rawLimit);
 }
 
 const config = loadConfig();

--- a/src/__tests__/cli-logs.test.ts
+++ b/src/__tests__/cli-logs.test.ts
@@ -1,0 +1,50 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const originalArgv = process.argv.slice();
+const originalExit = process.exit;
+
+describe("automaton-cli logs validation", () => {
+  beforeEach(() => {
+    vi.resetModules();
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    process.argv = originalArgv.slice();
+    process.exit = originalExit;
+    vi.restoreAllMocks();
+    vi.resetModules();
+  });
+
+  it.each(["0", "-1", "abc"])("rejects invalid --tail value %s", async (value) => {
+    const logSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+    const exitSpy = vi
+      .spyOn(process, "exit")
+      .mockImplementation(((code?: number) => {
+        throw new Error(`process.exit:${code ?? 0}`);
+      }) as typeof process.exit);
+
+    process.argv = ["node", "automaton-cli", "logs", "--tail", value];
+
+    await expect(import("../../packages/cli/src/commands/logs.ts")).rejects.toThrow("process.exit:1");
+
+    expect(exitSpy).toHaveBeenCalledWith(1);
+    expect(logSpy).toHaveBeenCalledWith("Invalid --tail value. Expected a positive integer.");
+  });
+
+  it("rejects missing --tail value", async () => {
+    const logSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+    const exitSpy = vi
+      .spyOn(process, "exit")
+      .mockImplementation(((code?: number) => {
+        throw new Error(`process.exit:${code ?? 0}`);
+      }) as typeof process.exit);
+
+    process.argv = ["node", "automaton-cli", "logs", "--tail"];
+
+    await expect(import("../../packages/cli/src/commands/logs.ts")).rejects.toThrow("process.exit:1");
+
+    expect(exitSpy).toHaveBeenCalledWith(1);
+    expect(logSpy).toHaveBeenCalledWith("Invalid --tail value. Expected a positive integer.");
+  });
+});


### PR DESCRIPTION
## Summary
- validate `automaton-cli logs --tail` before querying the database
- reject missing, zero, negative, and non-numeric tail values with a clear CLI error
- add focused CLI tests for invalid tail arguments

## Validation
- `npm test src/__tests__/cli-logs.test.ts`
- `npm run typecheck`
- `npx pnpm@10.28.1 build`