### PR TITLE
Cap tiktoken input length in countTokens to avoid O(n^2) hang

### DIFF
--- a/src/__tests__/memory/context-manager.test.ts
+++ b/src/__tests__/memory/context-manager.test.ts
@@ -87,6 +87,22 @@ describe("createTokenCounter", () => {
     expect(counter.cache.has("default::evict-0")).toBe(false);
     expect(counter.cache.has("default::evict-10004")).toBe(true);
   });
+
+  it("uses the char heuristic above the tokenize cap without hanging", () => {
+    const counter = createTokenCounter();
+
+    // A long whitespace-free run is the pathological input for js-tiktoken's
+    // O(n^2) BPE. Above the cap we must fall back to the char heuristic and
+    // return promptly instead of blocking the event loop for minutes.
+    const huge = "a".repeat(50_000);
+
+    const start = Date.now();
+    const count = counter.countTokens(huge);
+    const elapsed = Date.now() - start;
+
+    expect(count).toBe(Math.ceil(huge.length / 3.5));
+    expect(elapsed).toBeLessThan(1_000);
+  });
 });
 
 describe("ContextManager.assembleContext", () => {

--- a/src/memory/context-manager.ts
+++ b/src/memory/context-manager.ts
@@ -149,8 +149,15 @@ export function createTokenCounter(): TokenCounter {
       return cached;
     }
 
+    // js-tiktoken's BPE is O(n^2) on long whitespace-free runs, so tokenizing
+    // very large results (e.g. a 10k+ char tool output) can hang for minutes.
+    // Such content is only ever used here for budget estimation and is
+    // truncated before rendering, so fall back to the char heuristic above the
+    // cap instead of paying the quadratic cost.
+    const TOKENIZE_CAP = 8_000;
+
     let count: number;
-    if (encoder) {
+    if (encoder && normalizedText.length <= TOKENIZE_CAP) {
       try {
         count = encoder.encode(normalizedText).length;
       } catch {


### PR DESCRIPTION
## Problem

`createTokenCounter().countTokens()` runs js-tiktoken's `encode()` on the full input string. js-tiktoken's BPE is O(n²) on long whitespace-free runs, so tokenizing a large tool result (e.g. a 10k+ char output with no spaces) pegs a core and blocks the event loop for minutes. This is reproducible on both Linux and Windows and causes the `context-hardening` suite to hang (the worker sits at ~98% CPU and the per-test timeout never fires because the event loop is blocked).

## Fix

`countTokens` only uses the result for **budget estimation**, and the underlying text is truncated before rendering. So above an 8k-char cap, fall back to the existing `char / 3.5` heuristic instead of paying the quadratic cost. Below the cap, behavior is unchanged.

## Test

Adds a regression test asserting that a 50k-char whitespace-free string returns the heuristic count promptly (<1s) rather than hanging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)