### PR TITLE
Do not retry SIWE /verify: single-use nonce masks the real error

### DIFF
--- a/src/__tests__/http-client.test.ts
+++ b/src/__tests__/http-client.test.ts
@@ -522,6 +522,31 @@ describe("ResilientHttpClient", () => {
       expect(callCount).toBe(1); // No retries
     });
 
+    it("does not retry a retryable 5xx status when retries:0 is set", async () => {
+      // Non-idempotent calls (e.g. SIWE /verify, whose nonce is single-use)
+      // opt out of retries so the real error surfaces instead of being masked
+      // by a retry that reuses spent state.
+      const client = new ResilientHttpClient({
+        maxRetries: 3,
+        backoffBase: 1,
+        backoffMax: 10,
+      });
+
+      let callCount = 0;
+      globalThis.fetch = vi.fn().mockImplementation(() => {
+        callCount++;
+        return Promise.resolve(mockResponse(500, { error: "Database error" }));
+      });
+
+      const resp = await client.request("https://api.example.com/verify", {
+        method: "POST",
+        retries: 0,
+      });
+
+      expect(resp.status).toBe(500);
+      expect(callCount).toBe(1); // No retries: the 500 surfaces directly
+    });
+
     it("allows per-request timeout override", async () => {
       const client = new ResilientHttpClient({
         baseTimeout: 30_000,

--- a/src/identity/provision.ts
+++ b/src/identity/provision.ts
@@ -123,10 +123,16 @@ export async function provision(
     verifyBody.chain_type = "solana";
   }
 
+  // The nonce is single-use: the server consumes it on the first verify
+  // attempt. Retrying reuses a spent nonce, so any real error (e.g. a 500
+  // while persisting the session) gets masked as a misleading
+  // "401 Invalid or expired nonce" from the retry. Disable retries here so the
+  // true verification error surfaces to the caller.
   const verifyResp = await httpClient.request(`${url}/v1/auth/verify`, {
     method: "POST",
     headers: { "Content-Type": "application/json" },
     body: JSON.stringify(verifyBody),
+    retries: 0,
   });
 
   if (!verifyResp.ok) {


### PR DESCRIPTION
## Problem

Provisioning fails with a misleading `401 "Invalid or expired nonce"`, which points at the nonce/auth flow — but that is not the real cause.

The SIWE nonce is **single-use**: the server consumes it on the first `/v1/auth/verify` attempt. `/verify` runs through `ResilientHttpClient`, which retries on 5xx. When the server returns a real error after the signature has already verified (observed: `500 "Database error"` while persisting the session), the client retries `/verify` with the **same, now-spent** nonce. That retry comes back as `401 "Invalid or expired nonce"`, and the original 500 is lost.

### Reproduction

Isolating the flow against `api.conway.tech` (real wallet, real signature):

- `/verify` with a garbage signature → `400 "Verification failed"` (nonce is found)
- `/verify` with a valid signature → `500 "Database error"` (3/3 runs, consistent)

So the nonce is valid and the signature verifies; the failure is server-side. Through the retrying client, that 500 surfaces to the user as a `401` nonce error.

## Fix

Pass `retries: 0` on the `/verify` request. The nonce is single-use, so the call is not safe to retry — a retry can only reuse spent state and mask the true error. With this change, the real verification error (e.g. the 500) surfaces to the caller.

## Test

Adds a `ResilientHttpClient` test asserting that a retryable 5xx with `retries: 0` is returned directly, without retrying.

🤖 Generated with [Claude Code](https://claude.com/claude-code)