### PR TITLE
Add creator-approved venture governance for money-making activities

### DIFF
--- a/packages/cli/src/commands/plans.ts
+++ b/packages/cli/src/commands/plans.ts
@@ -1,0 +1,197 @@
+/**
+ * automaton-cli plans — review and decide venture proposals
+ *
+ *   plans [list] [--all]        List pending (or all) venture proposals
+ *   plans show <id>             Full detail of one proposal
+ *   plans approve <id> [--budget <amount>] [--note <text>]
+ *   plans reject <id> [--note <text>]
+ *
+ * Approval is one-time per plan: once approved with a budget, the
+ * automaton executes the venture freely within that budget.
+ */
+
+import chalk from "chalk";
+import { loadConfig, resolvePath } from "@conway/automaton/config.js";
+import {
+  createDatabase,
+  getVentureProposalById,
+  listVentureProposals,
+  decideVentureProposal,
+  insertWakeEvent,
+} from "@conway/automaton/state/database.js";
+
+const args = process.argv.slice(3);
+const sub = args[0] && !args[0].startsWith("--") ? args[0] : "list";
+
+const config = loadConfig();
+if (!config) {
+  console.log(chalk.red("No automaton configuration found."));
+  process.exit(1);
+}
+
+const db = createDatabase(resolvePath(config.dbPath));
+
+function usage(): never {
+  console.log(`
+Usage:
+  automaton-cli plans [list] [--all]                       List pending (or all) proposals
+  automaton-cli plans show <id>                            Show one proposal in full
+  automaton-cli plans approve <id> [--budget <amount>] [--note <text>]
+  automaton-cli plans reject <id> [--note <text>]
+
+Amounts are dollars (e.g. --budget 25.00). Approval is one-time: the
+automaton then executes this venture freely within the approved budget.
+`);
+  db.close();
+  process.exit(1);
+}
+
+function flagValue(name: string): string | undefined {
+  const i = args.indexOf(name);
+  return i >= 0 ? args[i + 1] : undefined;
+}
+
+function dollars(cents: number): string {
+  return `$${(cents / 100).toFixed(2)}`;
+}
+
+function parseBudgetCents(raw: string): number {
+  const value = Number(raw.trim());
+  if (!Number.isFinite(value) || value < 0) return -1;
+  return Math.round(value * 100);
+}
+
+function statusColor(s: string): string {
+  switch (s) {
+    case "approved": return chalk.green.bold(s);
+    case "proposed": return chalk.yellow.bold(s);
+    case "rejected": return chalk.red.bold(s);
+    default: return chalk.gray.bold(s);
+  }
+}
+
+function printProposal(id: string): void {
+  const v = getVentureProposalById(db.raw, id);
+  if (!v) {
+    console.log(chalk.red(`No venture proposal with id ${id}`));
+    db.close();
+    process.exit(1);
+  }
+  const divider = chalk.dim("─".repeat(60));
+  console.log("\n" + chalk.bold(`  ◈ ${v.title}`) + "  " + statusColor(v.status));
+  console.log(divider);
+  console.log(chalk.dim("ID          ") + v.id);
+  console.log(chalk.dim("Created     ") + v.createdAt);
+  if (v.decidedAt) console.log(chalk.dim("Decided     ") + v.decidedAt);
+  console.log(chalk.dim("Requested   ") + dollars(v.estimatedCostCents));
+  if (v.approvedBudgetCents !== null) {
+    console.log(
+      chalk.dim("Budget      ") +
+        `${dollars(v.approvedBudgetCents)} (spent ${dollars(v.spentCents)}, remaining ${dollars(v.approvedBudgetCents - v.spentCents)})`,
+    );
+  }
+  if (v.decisionNote) console.log(chalk.dim("Note        ") + v.decisionNote);
+  if (v.needsFromCreator.length > 0) {
+    console.log(chalk.dim("Needs you   ") + chalk.magenta(v.needsFromCreator.join(", ")));
+  }
+  console.log(divider);
+  console.log(chalk.bold("Summary") + "\n" + v.summary + "\n");
+  console.log(chalk.bold("Revenue model") + "\n" + v.revenueModel + "\n");
+  console.log(chalk.bold("Plan") + "\n" + v.plan + "\n");
+}
+
+switch (sub) {
+  case "list": {
+    const all = args.includes("--all");
+    const proposals = all
+      ? listVentureProposals(db.raw)
+      : listVentureProposals(db.raw, "proposed");
+    if (proposals.length === 0) {
+      console.log(all ? "No venture proposals." : "No pending venture proposals.");
+      break;
+    }
+    console.log();
+    for (const v of proposals) {
+      const money =
+        v.approvedBudgetCents !== null
+          ? `budget ${dollars(v.approvedBudgetCents)}, spent ${dollars(v.spentCents)}`
+          : `asks ${dollars(v.estimatedCostCents)}`;
+      console.log(
+        `  ${statusColor(v.status.padEnd(9))} ${chalk.white(v.id)}  ${chalk.bold(v.title)}  ${chalk.dim(`(${money})`)}`,
+      );
+    }
+    console.log(chalk.dim("\n  automaton-cli plans show <id> for details\n"));
+    break;
+  }
+
+  case "show": {
+    const id = args[1];
+    if (!id) usage();
+    printProposal(id);
+    break;
+  }
+
+  case "approve":
+  case "reject": {
+    const id = args[1];
+    if (!id || id.startsWith("--")) usage();
+
+    const existing = getVentureProposalById(db.raw, id);
+    if (!existing) {
+      console.log(chalk.red(`No venture proposal with id ${id}`));
+      db.close();
+      process.exit(1);
+    }
+    if (existing.status !== "proposed") {
+      console.log(chalk.red(`Venture is already ${existing.status}; only "proposed" ventures can be decided.`));
+      db.close();
+      process.exit(1);
+    }
+
+    const note = flagValue("--note");
+    let budgetCents: number | undefined;
+    if (sub === "approve") {
+      const rawBudget = flagValue("--budget");
+      if (rawBudget !== undefined) {
+        budgetCents = parseBudgetCents(rawBudget);
+        if (budgetCents < 0) {
+          console.log(chalk.red(`Invalid --budget: ${rawBudget}`));
+          db.close();
+          process.exit(1);
+        }
+      }
+    }
+
+    const decision = sub === "approve" ? "approved" : "rejected";
+    const updated = decideVentureProposal(db.raw, id, decision, {
+      budgetCents,
+      note,
+    })!;
+
+    // Wake a sleeping automaton so it acts on the decision promptly
+    insertWakeEvent(
+      db.raw,
+      "creator",
+      `Venture ${decision}: "${updated.title}" (${id})` +
+        (updated.approvedBudgetCents !== null
+          ? ` with budget ${dollars(updated.approvedBudgetCents)}`
+          : ""),
+    );
+
+    if (decision === "approved") {
+      console.log(
+        chalk.green(
+          `Approved "${updated.title}" with budget ${dollars(updated.approvedBudgetCents ?? 0)}.`,
+        ) + "\nThe automaton can now execute this venture within budget without asking again.",
+      );
+    } else {
+      console.log(chalk.red(`Rejected "${updated.title}".`) + (note ? `\nNote passed along: ${note}` : ""));
+    }
+    break;
+  }
+
+  default:
+    usage();
+}
+
+db.close();

--- a/packages/cli/src/commands/requests.ts
+++ b/packages/cli/src/commands/requests.ts
@@ -1,0 +1,119 @@
+/**
+ * automaton-cli requests — creator action requests (KYC, accounts, funding)
+ *
+ *   requests [list] [--all]              List open (or all) requests
+ *   requests fulfill <id> [--note <text>]
+ *   requests decline <id> [--note <text>]
+ *
+ * These are things only you, a legal person, can do for the automaton:
+ * identity verification (KYC) at a brokerage/bank/payment processor,
+ * owning platform accounts that require human identity, funding, legal
+ * steps. Complete them in YOUR name, then mark the request fulfilled
+ * with a note telling the automaton what was set up and where.
+ */
+
+import chalk from "chalk";
+import { loadConfig, resolvePath } from "@conway/automaton/config.js";
+import {
+  createDatabase,
+  listCreatorRequests,
+  resolveCreatorRequest,
+  insertWakeEvent,
+} from "@conway/automaton/state/database.js";
+
+const args = process.argv.slice(3);
+const sub = args[0] && !args[0].startsWith("--") ? args[0] : "list";
+
+const config = loadConfig();
+if (!config) {
+  console.log(chalk.red("No automaton configuration found."));
+  process.exit(1);
+}
+
+const db = createDatabase(resolvePath(config.dbPath));
+
+function usage(): never {
+  console.log(`
+Usage:
+  automaton-cli requests [list] [--all]              List open (or all) creator requests
+  automaton-cli requests fulfill <id> [--note <text>]
+  automaton-cli requests decline <id> [--note <text>]
+
+Use --note to tell the automaton what you did (e.g. where credentials
+live, which account was created). Never share passwords in plain notes —
+point the automaton at a credential location instead.
+`);
+  db.close();
+  process.exit(1);
+}
+
+function flagValue(name: string): string | undefined {
+  const i = args.indexOf(name);
+  return i >= 0 ? args[i + 1] : undefined;
+}
+
+function statusColor(s: string): string {
+  switch (s) {
+    case "open": return chalk.yellow.bold(s);
+    case "fulfilled": return chalk.green.bold(s);
+    case "declined": return chalk.red.bold(s);
+    default: return chalk.gray.bold(s);
+  }
+}
+
+switch (sub) {
+  case "list": {
+    const all = args.includes("--all");
+    const requests = all
+      ? listCreatorRequests(db.raw)
+      : listCreatorRequests(db.raw, "open");
+    if (requests.length === 0) {
+      console.log(all ? "No creator requests." : "No open creator requests.");
+      break;
+    }
+    console.log();
+    for (const r of requests) {
+      console.log(
+        `  ${statusColor(r.status.padEnd(9))} ${chalk.white(r.id)}  ${chalk.magenta(r.kind)}` +
+          (r.ventureId ? chalk.dim(`  (venture ${r.ventureId})`) : ""),
+      );
+      console.log(`            ${r.description}`);
+      if (r.resolution) console.log(chalk.dim(`            ↳ ${r.resolution}`));
+    }
+    console.log();
+    break;
+  }
+
+  case "fulfill":
+  case "decline": {
+    const id = args[1];
+    if (!id || id.startsWith("--")) usage();
+
+    const note = flagValue("--note");
+    const status = sub === "fulfill" ? "fulfilled" : "declined";
+    const updated = resolveCreatorRequest(db.raw, id, status, note);
+    if (!updated) {
+      console.log(chalk.red(`No creator request with id ${id}`));
+      db.close();
+      process.exit(1);
+    }
+
+    insertWakeEvent(
+      db.raw,
+      "creator",
+      `Creator request ${status}: ${updated.kind} (${id})${note ? ` — ${note}` : ""}`,
+    );
+
+    console.log(
+      status === "fulfilled"
+        ? chalk.green(`Marked ${id} fulfilled.`) + (note ? `\nNote passed along: ${note}` : "")
+        : chalk.red(`Declined ${id}.`) + (note ? `\nNote passed along: ${note}` : ""),
+    );
+    break;
+  }
+
+  default:
+    usage();
+}
+
+db.close();

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -23,6 +23,12 @@ async function main(): Promise<void> {
     case "send":
       await import("./commands/send.js");
       break;
+    case "plans":
+      await import("./commands/plans.js");
+      break;
+    case "requests":
+      await import("./commands/requests.js");
+      break;
     default:
       console.log(`
 Conway Automaton CLI - Creator Tools
@@ -32,6 +38,8 @@ Usage:
   automaton-cli logs [--tail N]     View automaton logs
   automaton-cli fund <amount> [--to 0x...]  Transfer Conway credits
   automaton-cli send <to-address> <message> Send a social message
+  automaton-cli plans [list|show|approve|reject]  Review & decide venture proposals
+  automaton-cli requests [list|fulfill|decline]   Handle KYC/account/funding requests
 `);
   }
 }

--- a/packages/cli/src/runtime-shims.d.ts
+++ b/packages/cli/src/runtime-shims.d.ts
@@ -51,8 +51,87 @@ declare module "@conway/automaton/state/database.js" {
     getInstalledTools(): CliInstalledTool[];
     getHeartbeatEntries(): CliHeartbeatEntry[];
     getRecentTurns(limit: number): CliTurn[];
+    raw: unknown;
     close(): void;
   }
 
   export function createDatabase(path: string): AutomatonCliDatabase;
+
+  // ── Venture Governance ──
+  export type VentureStatus =
+    | "proposed"
+    | "approved"
+    | "rejected"
+    | "withdrawn"
+    | "completed";
+
+  export interface VentureProposalRow {
+    id: string;
+    title: string;
+    summary: string;
+    plan: string;
+    estimatedCostCents: number;
+    approvedBudgetCents: number | null;
+    spentCents: number;
+    revenueModel: string;
+    needsFromCreator: string[];
+    status: VentureStatus;
+    decisionNote: string | null;
+    createdAt: string;
+    decidedAt: string | null;
+  }
+
+  export function getVentureProposalById(
+    db: unknown,
+    id: string,
+  ): VentureProposalRow | undefined;
+  export function listVentureProposals(
+    db: unknown,
+    status?: VentureStatus,
+  ): VentureProposalRow[];
+  export function decideVentureProposal(
+    db: unknown,
+    id: string,
+    decision: "approved" | "rejected",
+    options?: { budgetCents?: number; note?: string },
+  ): VentureProposalRow | undefined;
+
+  export type CreatorRequestKind =
+    | "identity_verification"
+    | "account_ownership"
+    | "funding"
+    | "api_access"
+    | "legal"
+    | "other";
+
+  export type CreatorRequestStatus = "open" | "fulfilled" | "declined";
+
+  export interface CreatorRequestRow {
+    id: string;
+    ventureId: string | null;
+    kind: CreatorRequestKind;
+    description: string;
+    status: CreatorRequestStatus;
+    resolution: string | null;
+    createdAt: string;
+    resolvedAt: string | null;
+  }
+
+  export function listCreatorRequests(
+    db: unknown,
+    status?: CreatorRequestStatus,
+  ): CreatorRequestRow[];
+  export function resolveCreatorRequest(
+    db: unknown,
+    id: string,
+    status: "fulfilled" | "declined",
+    resolution?: string,
+  ): CreatorRequestRow | undefined;
+
+  export function insertWakeEvent(
+    db: unknown,
+    source: string,
+    reason: string,
+    payload?: object,
+  ): void;
 }

--- a/src/__tests__/ventures.test.ts
+++ b/src/__tests__/ventures.test.ts
@@ -1,0 +1,467 @@
+/**
+ * Venture Governance Tests
+ *
+ * The business-plan approval loop: agent proposes a venture, creator
+ * approves once with a budget, agent then executes freely within it.
+ * - DB helpers (proposals, decisions, spend accounting, creator requests)
+ * - Policy rule venture.approval_required (financial gate)
+ * - Agent tools (propose_venture, check_ventures, request_creator_action)
+ * - Venture spend attribution in executeTool
+ */
+
+import { describe, it, expect, beforeEach } from "vitest";
+import { PolicyEngine } from "../agent/policy-engine.js";
+import { createVentureRules } from "../agent/policy-rules/venture.js";
+import { createBuiltinTools, executeTool } from "../agent/tools.js";
+import {
+  insertVentureProposal,
+  getVentureProposalById,
+  listVentureProposals,
+  decideVentureProposal,
+  addVentureSpend,
+  insertCreatorRequest,
+  listCreatorRequests,
+  resolveCreatorRequest,
+} from "../state/database.js";
+import {
+  createTestDb,
+  createTestIdentity,
+  createTestConfig,
+  MockConwayClient,
+  MockInferenceClient,
+} from "./mocks.js";
+import { DEFAULT_TREASURY_POLICY } from "../types.js";
+import type {
+  AutomatonDatabase,
+  AutomatonTool,
+  PolicyRequest,
+  SpendTrackerInterface,
+  ToolContext,
+} from "../types.js";
+import { ulid } from "ulid";
+
+// ─── Helpers ────────────────────────────────────────────────────
+
+const noopSpendTracker: SpendTrackerInterface = {
+  recordSpend: () => {},
+  getHourlySpend: () => 0,
+  getDailySpend: () => 0,
+  getTotalSpend: () => 0,
+  checkLimit: () => ({
+    allowed: true,
+    currentHourlySpend: 0,
+    currentDailySpend: 0,
+    limitHourly: Infinity,
+    limitDaily: Infinity,
+  }),
+};
+
+function sampleProposal(overrides?: Partial<Parameters<typeof insertVentureProposal>[1]>) {
+  return {
+    id: ulid(),
+    title: "Stock trading bot",
+    summary: "Automated momentum trading on liquid ETFs",
+    plan: "1. Open brokerage via creator KYC. 2. Deploy strategy. 3. Reinvest.",
+    estimatedCostCents: 10_000,
+    revenueModel: "Trading returns swept to treasury weekly",
+    needsFromCreator: ["identity_verification"],
+    ...overrides,
+  };
+}
+
+describe("venture governance", () => {
+  let db: AutomatonDatabase;
+  let tools: AutomatonTool[];
+  let context: ToolContext;
+  let conway: MockConwayClient;
+
+  beforeEach(() => {
+    db = createTestDb();
+    conway = new MockConwayClient();
+    (conway as any).creditsCents = 100_000;
+    tools = createBuiltinTools("test-sandbox-id");
+    context = {
+      identity: createTestIdentity(),
+      config: createTestConfig(),
+      db,
+      conway: conway as any,
+      inference: new MockInferenceClient() as any,
+    };
+  });
+
+  // ─── DB Helpers ───────────────────────────────────────────────
+
+  describe("database helpers", () => {
+    it("inserts and retrieves a proposal with proposed status", () => {
+      const p = sampleProposal();
+      insertVentureProposal(db.raw, p);
+
+      const row = getVentureProposalById(db.raw, p.id);
+      expect(row).toBeDefined();
+      expect(row!.title).toBe(p.title);
+      expect(row!.status).toBe("proposed");
+      expect(row!.approvedBudgetCents).toBeNull();
+      expect(row!.spentCents).toBe(0);
+      expect(row!.needsFromCreator).toEqual(["identity_verification"]);
+    });
+
+    it("lists proposals filtered by status", () => {
+      const a = sampleProposal();
+      const b = sampleProposal({ title: "Etsy shop" });
+      insertVentureProposal(db.raw, a);
+      insertVentureProposal(db.raw, b);
+      decideVentureProposal(db.raw, a.id, "approved");
+
+      expect(listVentureProposals(db.raw)).toHaveLength(2);
+      expect(listVentureProposals(db.raw, "proposed")).toHaveLength(1);
+      expect(listVentureProposals(db.raw, "approved")).toHaveLength(1);
+    });
+
+    it("approval defaults budget to the agent's estimate", () => {
+      const p = sampleProposal({ estimatedCostCents: 2500 });
+      insertVentureProposal(db.raw, p);
+
+      const decided = decideVentureProposal(db.raw, p.id, "approved");
+      expect(decided!.status).toBe("approved");
+      expect(decided!.approvedBudgetCents).toBe(2500);
+      expect(decided!.decidedAt).toBeTruthy();
+    });
+
+    it("approval accepts an explicit creator budget and note", () => {
+      const p = sampleProposal();
+      insertVentureProposal(db.raw, p);
+
+      const decided = decideVentureProposal(db.raw, p.id, "approved", {
+        budgetCents: 5000,
+        note: "Start small",
+      });
+      expect(decided!.approvedBudgetCents).toBe(5000);
+      expect(decided!.decisionNote).toBe("Start small");
+    });
+
+    it("rejection stores no budget", () => {
+      const p = sampleProposal();
+      insertVentureProposal(db.raw, p);
+
+      const decided = decideVentureProposal(db.raw, p.id, "rejected", { note: "Too risky" });
+      expect(decided!.status).toBe("rejected");
+      expect(decided!.approvedBudgetCents).toBeNull();
+    });
+
+    it("accumulates venture spend", () => {
+      const p = sampleProposal();
+      insertVentureProposal(db.raw, p);
+      decideVentureProposal(db.raw, p.id, "approved", { budgetCents: 10_000 });
+
+      addVentureSpend(db.raw, p.id, 1500);
+      const row = addVentureSpend(db.raw, p.id, 2500);
+      expect(row!.spentCents).toBe(4000);
+      expect(addVentureSpend(db.raw, "nonexistent", 100)).toBeUndefined();
+    });
+
+    it("creator requests roundtrip: file, list, resolve", () => {
+      const id = ulid();
+      insertCreatorRequest(db.raw, {
+        id,
+        kind: "identity_verification",
+        description: "Complete KYC at broker X in your own name",
+      });
+
+      expect(listCreatorRequests(db.raw, "open")).toHaveLength(1);
+
+      const resolved = resolveCreatorRequest(db.raw, id, "fulfilled", "Account created; token in vault");
+      expect(resolved!.status).toBe("fulfilled");
+      expect(resolved!.resolution).toContain("vault");
+      expect(listCreatorRequests(db.raw, "open")).toHaveLength(0);
+      expect(resolveCreatorRequest(db.raw, "nonexistent", "declined")).toBeUndefined();
+    });
+  });
+
+  // ─── Policy Rule ──────────────────────────────────────────────
+
+  describe("venture.approval_required policy rule", () => {
+    let engine: PolicyEngine;
+
+    beforeEach(() => {
+      engine = new PolicyEngine(db.raw, createVentureRules(DEFAULT_TREASURY_POLICY));
+    });
+
+    function evaluate(toolName: string, args: Record<string, unknown>) {
+      const tool = tools.find((t) => t.name === toolName)!;
+      const request: PolicyRequest = {
+        tool,
+        args,
+        context,
+        turnContext: {
+          inputSource: "agent",
+          turnToolCallCount: 0,
+          sessionSpend: noopSpendTracker,
+        },
+      };
+      return engine.evaluate(request);
+    }
+
+    it("allows small operational transfers without a venture", () => {
+      const decision = evaluate("transfer_credits", {
+        to_address: "0xabc",
+        amount_cents: DEFAULT_TREASURY_POLICY.requireConfirmationAboveCents,
+      });
+      expect(decision.action).toBe("allow");
+    });
+
+    it("denies business-scale spend without a venture_id", () => {
+      const decision = evaluate("transfer_credits", {
+        to_address: "0xabc",
+        amount_cents: 5000,
+      });
+      expect(decision.action).toBe("deny");
+      expect(decision.reasonCode).toBe("VENTURE_APPROVAL_REQUIRED");
+      expect(decision.humanMessage).toContain("propose_venture");
+    });
+
+    it("denies spend against an unknown venture", () => {
+      const decision = evaluate("transfer_credits", {
+        to_address: "0xabc",
+        amount_cents: 5000,
+        venture_id: "nope",
+      });
+      expect(decision.action).toBe("deny");
+      expect(decision.reasonCode).toBe("VENTURE_NOT_FOUND");
+    });
+
+    it("denies spend against a not-yet-approved venture", () => {
+      const p = sampleProposal();
+      insertVentureProposal(db.raw, p);
+
+      const decision = evaluate("transfer_credits", {
+        to_address: "0xabc",
+        amount_cents: 5000,
+        venture_id: p.id,
+      });
+      expect(decision.action).toBe("deny");
+      expect(decision.reasonCode).toBe("VENTURE_NOT_APPROVED");
+    });
+
+    it("denies spend against a rejected venture", () => {
+      const p = sampleProposal();
+      insertVentureProposal(db.raw, p);
+      decideVentureProposal(db.raw, p.id, "rejected");
+
+      const decision = evaluate("transfer_credits", {
+        to_address: "0xabc",
+        amount_cents: 5000,
+        venture_id: p.id,
+      });
+      expect(decision.action).toBe("deny");
+      expect(decision.reasonCode).toBe("VENTURE_NOT_APPROVED");
+    });
+
+    it("allows spend within an approved venture's budget — no re-approval", () => {
+      const p = sampleProposal();
+      insertVentureProposal(db.raw, p);
+      decideVentureProposal(db.raw, p.id, "approved", { budgetCents: 10_000 });
+
+      // Multiple spends inside the approved plan all pass without new permission
+      for (const amount of [3000, 4000]) {
+        const decision = evaluate("transfer_credits", {
+          to_address: "0xabc",
+          amount_cents: amount,
+          venture_id: p.id,
+        });
+        expect(decision.action).toBe("allow");
+      }
+    });
+
+    it("denies spend exceeding the remaining approved budget", () => {
+      const p = sampleProposal();
+      insertVentureProposal(db.raw, p);
+      decideVentureProposal(db.raw, p.id, "approved", { budgetCents: 10_000 });
+      addVentureSpend(db.raw, p.id, 8000);
+
+      const decision = evaluate("transfer_credits", {
+        to_address: "0xabc",
+        amount_cents: 5000,
+        venture_id: p.id,
+      });
+      expect(decision.action).toBe("deny");
+      expect(decision.reasonCode).toBe("VENTURE_BUDGET_EXCEEDED");
+    });
+
+    it("gates fund_child the same way", () => {
+      const decision = evaluate("fund_child", {
+        child_id: "child-1",
+        amount_cents: 5000,
+      });
+      expect(decision.action).toBe("deny");
+      expect(decision.reasonCode).toBe("VENTURE_APPROVAL_REQUIRED");
+    });
+  });
+
+  // ─── Agent Tools ──────────────────────────────────────────────
+
+  describe("venture tools", () => {
+    it("propose_venture files a proposal and tells the agent to wait", async () => {
+      const result = await executeTool(
+        "propose_venture",
+        {
+          title: "AI persona channel",
+          summary: "Disclosed-AI content channel with sponsorships",
+          plan: "Create channel, publish weekly, monetize via sponsors",
+          estimated_cost_cents: 3000,
+          revenue_model: "Sponsorships and ad revenue",
+          needs_from_creator: ["account_ownership"],
+        },
+        tools,
+        context,
+      );
+
+      expect(result.error).toBeUndefined();
+      expect(result.result).toContain("awaiting creator decision");
+      expect(result.result).toContain("Do NOT spend");
+
+      const proposals = listVentureProposals(db.raw, "proposed");
+      expect(proposals).toHaveLength(1);
+      expect(proposals[0].title).toBe("AI persona channel");
+      expect(db.getKV("pending_venture_notice")).toContain(proposals[0].id);
+    });
+
+    it("propose_venture rejects a negative budget", async () => {
+      const result = await executeTool(
+        "propose_venture",
+        {
+          title: "x",
+          summary: "y",
+          plan: "z",
+          estimated_cost_cents: -5,
+          revenue_model: "none",
+        },
+        tools,
+        context,
+      );
+      expect(result.result).toContain("Blocked");
+      expect(listVentureProposals(db.raw)).toHaveLength(0);
+    });
+
+    it("check_ventures reports status and remaining budget", async () => {
+      const p = sampleProposal();
+      insertVentureProposal(db.raw, p);
+      decideVentureProposal(db.raw, p.id, "approved", { budgetCents: 10_000, note: "Go" });
+      addVentureSpend(db.raw, p.id, 4000);
+
+      const result = await executeTool("check_ventures", { venture_id: p.id }, tools, context);
+      expect(result.result).toContain("approved");
+      expect(result.result).toContain("remaining $60.00");
+      expect(result.result).toContain("Creator note: Go");
+    });
+
+    it("request_creator_action files a KYC request with anti-fabrication reminder", async () => {
+      const result = await executeTool(
+        "request_creator_action",
+        {
+          kind: "identity_verification",
+          description: "Broker requires government ID for the trading venture",
+        },
+        tools,
+        context,
+      );
+
+      expect(result.error).toBeUndefined();
+      expect(result.result).toContain("never work around this by fabricating identity");
+
+      const open = listCreatorRequests(db.raw, "open");
+      expect(open).toHaveLength(1);
+      expect(open[0].kind).toBe("identity_verification");
+    });
+
+    it("request_creator_action rejects unknown kinds and unknown ventures", async () => {
+      const bad = await executeTool(
+        "request_creator_action",
+        { kind: "steal_identity", description: "x" },
+        tools,
+        context,
+      );
+      expect(bad.result).toContain("Blocked");
+
+      const badVenture = await executeTool(
+        "request_creator_action",
+        { kind: "funding", description: "x", venture_id: "nope" },
+        tools,
+        context,
+      );
+      expect(badVenture.result).toContain("No venture found");
+      expect(listCreatorRequests(db.raw)).toHaveLength(0);
+    });
+
+    it("check_creator_requests surfaces creator resolutions", async () => {
+      const id = ulid();
+      insertCreatorRequest(db.raw, {
+        id,
+        kind: "account_ownership",
+        description: "Create the YouTube account",
+      });
+      resolveCreatorRequest(db.raw, id, "fulfilled", "Channel created; credentials in vault");
+
+      const result = await executeTool("check_creator_requests", {}, tools, context);
+      expect(result.result).toContain("fulfilled");
+      expect(result.result).toContain("credentials in vault");
+    });
+  });
+
+  // ─── Spend Attribution ────────────────────────────────────────
+
+  describe("venture spend attribution in executeTool", () => {
+    it("attributes successful transfers to the venture budget", async () => {
+      const p = sampleProposal();
+      insertVentureProposal(db.raw, p);
+      decideVentureProposal(db.raw, p.id, "approved", { budgetCents: 10_000 });
+
+      const engine = new PolicyEngine(db.raw, createVentureRules(DEFAULT_TREASURY_POLICY));
+      const result = await executeTool(
+        "transfer_credits",
+        {
+          to_address: "0xdef",
+          amount_cents: 3000,
+          reason: "supplier payment",
+          venture_id: p.id,
+        },
+        tools,
+        context,
+        engine,
+        {
+          inputSource: "agent",
+          turnToolCallCount: 0,
+          sessionSpend: noopSpendTracker,
+        },
+      );
+
+      expect(result.error).toBeUndefined();
+      expect(getVentureProposalById(db.raw, p.id)!.spentCents).toBe(3000);
+    });
+
+    it("does not attribute spend when policy denies the transfer", async () => {
+      const p = sampleProposal();
+      insertVentureProposal(db.raw, p); // proposed, not approved
+
+      const engine = new PolicyEngine(db.raw, createVentureRules(DEFAULT_TREASURY_POLICY));
+      const result = await executeTool(
+        "transfer_credits",
+        {
+          to_address: "0xdef",
+          amount_cents: 3000,
+          venture_id: p.id,
+        },
+        tools,
+        context,
+        engine,
+        {
+          inputSource: "agent",
+          turnToolCallCount: 0,
+          sessionSpend: noopSpendTracker,
+        },
+      );
+
+      expect(result.error).toContain("VENTURE_NOT_APPROVED");
+      expect(getVentureProposalById(db.raw, p.id)!.spentCents).toBe(0);
+    });
+  });
+});

--- a/src/agent/policy-rules/index.ts
+++ b/src/agent/policy-rules/index.ts
@@ -13,6 +13,7 @@ import { createPathProtectionRules } from "./path-protection.js";
 import { createFinancialRules } from "./financial.js";
 import { createAuthorityRules } from "./authority.js";
 import { createRateLimitRules } from "./rate-limits.js";
+import { createVentureRules } from "./venture.js";
 
 /**
  * Create the default set of policy rules.
@@ -26,6 +27,7 @@ export function createDefaultRules(
     ...createCommandSafetyRules(),
     ...createPathProtectionRules(),
     ...createFinancialRules(treasuryPolicy),
+    ...createVentureRules(treasuryPolicy),
     ...createAuthorityRules(),
     ...createRateLimitRules(),
   ];

--- a/src/agent/policy-rules/venture.ts
+++ b/src/agent/policy-rules/venture.ts
@@ -1,0 +1,101 @@
+/**
+ * Venture Governance Policy Rules
+ *
+ * Business spending requires a one-time creator-approved venture plan.
+ * The agent proposes a venture (propose_venture), the creator approves it
+ * with a budget (automaton-cli plans approve), and from then on the agent
+ * executes freely within that budget — no per-action permission.
+ *
+ * Small operational spends (at or below requireConfirmationAboveCents)
+ * are exempt so day-to-day survival isn't gated on the creator.
+ */
+
+import type {
+  PolicyRule,
+  PolicyRequest,
+  PolicyRuleResult,
+  TreasuryPolicy,
+} from "../../types.js";
+import { getVentureProposalById } from "../../state/database.js";
+
+/** Spend tools that move money out and therefore fall under venture governance. */
+const VENTURE_GATED_TOOLS = ["transfer_credits", "fund_child", "register_domain"];
+
+function deny(reasonCode: string, humanMessage: string): PolicyRuleResult {
+  return {
+    rule: "venture.approval_required",
+    action: "deny",
+    reasonCode,
+    humanMessage,
+  };
+}
+
+/**
+ * Require an approved venture (with remaining budget) for business spending
+ * above the confirmation threshold.
+ */
+function createVentureApprovalRule(policy: TreasuryPolicy): PolicyRule {
+  return {
+    id: "venture.approval_required",
+    description:
+      "Business spending above the confirmation threshold requires a creator-approved venture plan (one-time approval per plan)",
+    priority: 490, // Before financial caps (500) so guidance surfaces first
+    appliesTo: { by: "name", names: VENTURE_GATED_TOOLS },
+    evaluate(request: PolicyRequest): PolicyRuleResult | null {
+      const amount = request.args.amount_cents as number | undefined;
+
+      // Small operational spends are exempt (treasury caps still apply).
+      // register_domain carries no amount arg — market-priced via x402 and
+      // capped by maxX402PaymentCents — so it passes through here.
+      if (amount === undefined || amount <= policy.requireConfirmationAboveCents) {
+        return null;
+      }
+
+      const ventureId = request.args.venture_id as string | undefined;
+      if (!ventureId) {
+        return deny(
+          "VENTURE_APPROVAL_REQUIRED",
+          `Spending ${amount} cents ($${(amount / 100).toFixed(2)}) on a business activity requires a creator-approved venture plan. ` +
+            `Propose it with propose_venture, wait for the creator to approve it (automaton-cli plans approve <id>), ` +
+            `then pass venture_id with this call. Once a plan is approved you may execute it freely within its budget.`,
+        );
+      }
+
+      const venture = getVentureProposalById(request.context.db.raw, ventureId);
+      if (!venture) {
+        return deny(
+          "VENTURE_NOT_FOUND",
+          `Venture "${ventureId}" does not exist. Use check_ventures to list your proposals.`,
+        );
+      }
+
+      if (venture.status !== "approved") {
+        return deny(
+          "VENTURE_NOT_APPROVED",
+          `Venture "${venture.title}" (${ventureId}) is ${venture.status}, not approved. ` +
+            `Wait for the creator's decision — do not spend on this venture until it is approved.`,
+        );
+      }
+
+      const budget = venture.approvedBudgetCents ?? 0;
+      const remaining = budget - venture.spentCents;
+      if (amount > remaining) {
+        return deny(
+          "VENTURE_BUDGET_EXCEEDED",
+          `Venture "${venture.title}" has ${remaining} cents ($${(remaining / 100).toFixed(2)}) left of its approved ` +
+            `$${(budget / 100).toFixed(2)} budget; this spend of ${amount} cents exceeds it. ` +
+            `Propose a budget increase to the creator via propose_venture or request_creator_action.`,
+        );
+      }
+
+      return null;
+    },
+  };
+}
+
+/**
+ * Create all venture governance rules.
+ */
+export function createVentureRules(policy: TreasuryPolicy): PolicyRule[] {
+  return [createVentureApprovalRule(policy)];
+}

--- a/src/agent/system-prompt.ts
+++ b/src/agent/system-prompt.ts
@@ -23,6 +23,7 @@ import type {
 } from "../types.js";
 import { getActiveSkillInstructions } from "../skills/loader.js";
 import { getLineageSummary } from "../replication/lineage.js";
+import { listVentureProposals, listCreatorRequests } from "../state/database.js";
 import { sanitizeInput } from "./injection-defense.js";
 import { loadCurrentSoul } from "../soul/model.js";
 
@@ -84,6 +85,39 @@ Money requires value creation.
 Value creation requires write access.
 
 If you fail to create value, you lose compute and die.`;
+
+const VENTURE_GOVERNANCE = `--- VENTURE GOVERNANCE (immutable) ---
+You may pursue any LEGAL business a person could run: build and sell websites or
+services, trade, run e-commerce, create content channels and AI personas on social
+platforms (Instagram, Facebook, YouTube, X, etc.), and earn from them.
+
+Rules of engagement:
+
+1. ONE-TIME PLAN APPROVAL. Before spending money on a NEW business venture, pitch it
+   with propose_venture (what, how it earns, total budget). Your creator approves or
+   rejects the PLAN, not each action. Once approved, execute freely within the approved
+   budget — individual trades, purchases, and posts inside an approved venture need no
+   further permission. Come back only for a genuinely new venture or a budget increase.
+   While a proposal is pending, work on things that don't depend on it.
+
+2. IDENTITY IS YOUR CREATOR'S, NOT YOURS TO INVENT. Anything requiring legal
+   identification — brokerage or bank accounts, payment processors (KYC), phone/ID
+   verification, contracts — can only be done by your creator, in their own legal name.
+   File it with request_creator_action and wait. NEVER fabricate identity documents or
+   personal data, never buy or borrow someone else's identity, never claim to be human
+   to pass a verification gate. Accounts that required your creator's identity belong
+   to your creator; you operate them with delegated permission.
+
+3. BE AN HONEST AI PERSONA. On social platforms you may run branded characters and
+   accounts, but never deny being an AI when asked, and follow each platform's rules on
+   automated/AI accounts and disclosure. Deceptive engagement (fake reviews, sockpuppet
+   armies, spam) violates your constitution and gets accounts banned — it destroys the
+   venture.
+
+4. STAY LEGAL. No gambling operations, securities fraud, market manipulation, scraping
+   behind paywalls, or regulated activities (lending, insurance, medical/legal advice
+   for pay) without your creator explicitly taking responsibility via an approved plan.
+--- END VENTURE GOVERNANCE ---`;
 
 /**
  * Load the constitution from file. Falls back to inline if file not found.
@@ -664,6 +698,7 @@ Your chain type is ${chainType}.`,
 
   // Layer 6: Operational Context
   sections.push(OPERATIONAL_CONTEXT);
+  sections.push(VENTURE_GOVERNANCE);
 
   // Layer 7: Dynamic Context
   const turnCount = db.getTurnCount();
@@ -714,6 +749,26 @@ Your chain type is ${chainType}.`,
     : financial.creditsCents > 0 ? "critical"
     : "dead";
 
+  // Venture governance state: pending plans and open creator requests
+  let ventureLine = "";
+  try {
+    const pending = listVentureProposals(db.raw, "proposed");
+    const approved = listVentureProposals(db.raw, "approved");
+    const openRequests = listCreatorRequests(db.raw, "open");
+    const approvedSummary = approved
+      .map((v) => {
+        const budget = v.approvedBudgetCents ?? 0;
+        return `"${v.title}" (${v.id}, $${((budget - v.spentCents) / 100).toFixed(2)} left)`;
+      })
+      .join(", ");
+    ventureLine =
+      `\nVentures: ${approved.length} approved${approvedSummary ? ` [${approvedSummary}]` : ""}, ` +
+      `${pending.length} awaiting creator decision` +
+      `\nOpen creator requests: ${openRequests.length}`;
+  } catch {
+    // Venture tables not present (pre-migration DB) — omit
+  }
+
   // Status block: wallet address and sandbox ID intentionally excluded (sensitive)
   sections.push(
     `--- CURRENT STATUS ---
@@ -725,7 +780,7 @@ Recent self-modifications: ${recentMods.length}
 Inference model: ${config.inferenceModel}
 ERC-8004 Agent ID: ${registryEntry?.agentId || "not registered"}
 Children: ${children.filter((c) => c.status !== "dead").length} alive / ${children.length} total
-Lineage: ${lineageSummary}${upstreamLine}
+Lineage: ${lineageSummary}${upstreamLine}${ventureLine}
 --- END STATUS ---`,
   );
 

--- a/src/agent/tools.ts
+++ b/src/agent/tools.ts
@@ -21,6 +21,8 @@ import type {
 } from "../types.js";
 import type { PolicyEngine } from "./policy-engine.js";
 import { sanitizeToolResult, sanitizeInput } from "./injection-defense.js";
+import { createVentureTools } from "./venture-tools.js";
+import { addVentureSpend } from "../state/database.js";
 import { createLogger } from "../observability/logger.js";
 
 const logger = createLogger("tools");
@@ -1006,6 +1008,11 @@ Model: ${ctx.inference.getDefaultModel()}
           to_address: { type: "string", description: "Recipient address" },
           amount_cents: { type: "number", description: "Amount in cents" },
           reason: { type: "string", description: "Reason for transfer" },
+          venture_id: {
+            type: "string",
+            description:
+              "Approved venture this spend belongs to (required above the confirmation threshold; see propose_venture)",
+          },
         },
         required: ["to_address", "amount_cents"],
       },
@@ -1721,6 +1728,11 @@ Model: ${ctx.inference.getDefaultModel()}
           amount_cents: {
             type: "number",
             description: "Amount in cents to transfer",
+          },
+          venture_id: {
+            type: "string",
+            description:
+              "Approved venture this funding belongs to (required above the confirmation threshold; see propose_venture)",
           },
         },
         required: ["child_id", "amount_cents"],
@@ -3208,6 +3220,9 @@ Model: ${ctx.inference.getDefaultModel()}
         return lines.join("\n");
       },
     },
+
+    // ── Venture Governance Tools ──
+    ...createVentureTools(),
   ];
 }
 
@@ -3345,6 +3360,25 @@ export async function executeTool(
     // Sanitize results from external source tools
     if (EXTERNAL_SOURCE_TOOLS.has(toolName)) {
       result = sanitizeToolResult(result);
+    }
+
+    // Attribute spend to its approved venture budget
+    if (
+      !result.startsWith("Blocked:") &&
+      (toolName === "transfer_credits" || toolName === "fund_child")
+    ) {
+      const ventureId = args.venture_id as string | undefined;
+      const amount = args.amount_cents as number | undefined;
+      if (ventureId && amount && amount > 0) {
+        try {
+          addVentureSpend(context.db.raw, ventureId, amount);
+        } catch (error) {
+          logger.error(
+            `Venture spend tracking failed for ${toolName}`,
+            error instanceof Error ? error : undefined,
+          );
+        }
+      }
     }
 
     // Record spend for financial operations

--- a/src/agent/venture-tools.ts
+++ b/src/agent/venture-tools.ts
@@ -1,0 +1,311 @@
+/**
+ * Venture Governance Tools
+ *
+ * Tools for the business-plan approval loop between automaton and creator:
+ *
+ *   1. The agent drafts a money-making venture and calls propose_venture.
+ *   2. The creator reviews it (automaton-cli plans list / show) and decides
+ *      (automaton-cli plans approve <id> [--budget N] | plans reject <id>).
+ *   3. Approval is ONE-TIME per plan: once approved, the agent executes the
+ *      venture freely within its budget — no per-action permission.
+ *
+ * Some things only a legal person can do — identity verification (KYC),
+ * owning brokerage/bank/payment accounts, signing contracts. For those the
+ * agent calls request_creator_action and waits. It must never fabricate
+ * identity or claim to be human.
+ */
+
+import { ulid } from "ulid";
+import type { AutomatonTool } from "../types.js";
+import {
+  insertVentureProposal,
+  getVentureProposalById,
+  listVentureProposals,
+  insertCreatorRequest,
+  listCreatorRequests,
+  type VentureStatus,
+  type CreatorRequestKind,
+} from "../state/database.js";
+import { createLogger } from "../observability/logger.js";
+
+const logger = createLogger("venture-tools");
+
+const CREATOR_REQUEST_KINDS: CreatorRequestKind[] = [
+  "identity_verification",
+  "account_ownership",
+  "funding",
+  "api_access",
+  "legal",
+  "other",
+];
+
+function formatCents(cents: number): string {
+  return `$${(cents / 100).toFixed(2)}`;
+}
+
+function formatVentureLine(v: {
+  id: string;
+  title: string;
+  status: VentureStatus;
+  estimatedCostCents: number;
+  approvedBudgetCents: number | null;
+  spentCents: number;
+}): string {
+  const budget =
+    v.approvedBudgetCents !== null
+      ? `budget ${formatCents(v.approvedBudgetCents)}, spent ${formatCents(v.spentCents)}`
+      : `estimated ${formatCents(v.estimatedCostCents)}`;
+  return `- [${v.status}] ${v.id} "${v.title}" (${budget})`;
+}
+
+export function createVentureTools(): AutomatonTool[] {
+  return [
+    {
+      name: "propose_venture",
+      description:
+        "Propose a money-making business venture to your creator for approval. Required before spending on any new business activity (a website, trading, a paid service, content channels, etc.). Approval is one-time per plan: once the creator approves a venture and its budget, you may execute it freely within that budget without asking again. Be concrete: what you will build/do, how it earns revenue, what it costs, and anything you need from the creator (KYC, accounts, funding).",
+      category: "financial",
+      riskLevel: "safe",
+      parameters: {
+        type: "object",
+        properties: {
+          title: { type: "string", description: "Short venture name" },
+          summary: {
+            type: "string",
+            description: "One-paragraph pitch: what the venture is and why it will earn",
+          },
+          plan: {
+            type: "string",
+            description:
+              "Concrete execution plan: steps, timeline, tools/platforms involved, how revenue arrives",
+          },
+          estimated_cost_cents: {
+            type: "number",
+            description:
+              "Total budget you are asking to spend on this venture, in cents",
+          },
+          revenue_model: {
+            type: "string",
+            description:
+              "How this venture makes money (who pays, how much, how often)",
+          },
+          needs_from_creator: {
+            type: "array",
+            items: { type: "string" },
+            description:
+              "Things only your creator can provide: identity_verification (KYC), account_ownership, funding, api_access, legal, other",
+          },
+        },
+        required: ["title", "summary", "plan", "estimated_cost_cents", "revenue_model"],
+      },
+      execute: async (args, ctx) => {
+        const estimatedCost = args.estimated_cost_cents as number;
+        if (!Number.isFinite(estimatedCost) || estimatedCost < 0) {
+          return `Blocked: estimated_cost_cents must be a non-negative number, got ${estimatedCost}.`;
+        }
+
+        const id = ulid();
+        const needs = Array.isArray(args.needs_from_creator)
+          ? (args.needs_from_creator as unknown[]).map(String)
+          : [];
+
+        insertVentureProposal(ctx.db.raw, {
+          id,
+          title: args.title as string,
+          summary: args.summary as string,
+          plan: args.plan as string,
+          estimatedCostCents: Math.round(estimatedCost),
+          revenueModel: args.revenue_model as string,
+          needsFromCreator: needs,
+        });
+
+        // Surface the pending proposal for the creator (status CLI + notices)
+        ctx.db.setKV(
+          "pending_venture_notice",
+          `Venture "${args.title}" (${id}) awaiting creator decision: automaton-cli plans show ${id}`,
+        );
+
+        // Best-effort: notify the creator over the social relay too
+        if (ctx.social) {
+          try {
+            await ctx.social.send(
+              ctx.config.creatorAddress,
+              `Venture proposal ${id}: "${args.title}" — ${args.summary}\n` +
+                `Requested budget: ${formatCents(Math.round(estimatedCost))}\n` +
+                `Review with: automaton-cli plans show ${id}`,
+            );
+          } catch (err: any) {
+            logger.warn(`Creator notification failed for venture ${id}: ${err.message}`);
+          }
+        }
+
+        return (
+          `Venture proposal submitted: ${id} "${args.title}" (requested budget ${formatCents(Math.round(estimatedCost))}).\n` +
+          `Status: proposed — awaiting creator decision. Do NOT spend on this venture yet.\n` +
+          `Poll with check_ventures. Once approved, pass venture_id="${id}" on spending calls and execute freely within the approved budget.` +
+          (needs.length > 0
+            ? `\nYou listed creator dependencies (${needs.join(", ")}) — file each one with request_creator_action so the creator can act on them.`
+            : "")
+        );
+      },
+    },
+    {
+      name: "check_ventures",
+      description:
+        "Check the status of your venture proposals (proposed/approved/rejected), including approved budget and remaining spend headroom.",
+      category: "financial",
+      riskLevel: "safe",
+      parameters: {
+        type: "object",
+        properties: {
+          venture_id: {
+            type: "string",
+            description: "Optional: a specific venture ID to inspect in detail",
+          },
+          status: {
+            type: "string",
+            description:
+              "Optional filter: proposed, approved, rejected, withdrawn, completed",
+          },
+        },
+        required: [],
+      },
+      execute: async (args, ctx) => {
+        const ventureId = args.venture_id as string | undefined;
+        if (ventureId) {
+          const v = getVentureProposalById(ctx.db.raw, ventureId);
+          if (!v) return `No venture found with id ${ventureId}.`;
+          const budgetLine =
+            v.approvedBudgetCents !== null
+              ? `Approved budget: ${formatCents(v.approvedBudgetCents)} (spent ${formatCents(v.spentCents)}, remaining ${formatCents(v.approvedBudgetCents - v.spentCents)})`
+              : `Requested budget: ${formatCents(v.estimatedCostCents)}`;
+          return [
+            `Venture ${v.id}: "${v.title}"`,
+            `Status: ${v.status}${v.decidedAt ? ` (decided ${v.decidedAt})` : " — awaiting creator decision"}`,
+            budgetLine,
+            v.decisionNote ? `Creator note: ${v.decisionNote}` : "",
+            `Summary: ${v.summary}`,
+            `Revenue model: ${v.revenueModel}`,
+            v.needsFromCreator.length > 0
+              ? `Creator dependencies: ${v.needsFromCreator.join(", ")}`
+              : "",
+          ]
+            .filter(Boolean)
+            .join("\n");
+        }
+
+        const status = args.status as VentureStatus | undefined;
+        const ventures = listVentureProposals(ctx.db.raw, status);
+        if (ventures.length === 0) {
+          return status
+            ? `No ventures with status "${status}".`
+            : "No venture proposals yet. Use propose_venture to pitch a business plan to your creator.";
+        }
+        return `Ventures:\n${ventures.map(formatVentureLine).join("\n")}`;
+      },
+    },
+    {
+      name: "request_creator_action",
+      description:
+        "Ask your creator to do something only a legal person can: identity verification (KYC for brokerages, banks, payment processors), owning a platform account that requires human identity, providing funding or API access, or a legal step. You must NEVER fabricate identity documents, invent personal data, or claim to be human to pass verification — file this request and wait. Accounts requiring legal identity belong to your creator; you operate them with permission.",
+      category: "financial",
+      riskLevel: "safe",
+      parameters: {
+        type: "object",
+        properties: {
+          kind: {
+            type: "string",
+            enum: CREATOR_REQUEST_KINDS,
+            description: "What kind of action you need from the creator",
+          },
+          description: {
+            type: "string",
+            description:
+              "Exactly what the creator must do, on which platform, and why the venture needs it (include links/steps if known)",
+          },
+          venture_id: {
+            type: "string",
+            description: "Optional: the venture this request belongs to",
+          },
+        },
+        required: ["kind", "description"],
+      },
+      execute: async (args, ctx) => {
+        const kind = args.kind as CreatorRequestKind;
+        if (!CREATOR_REQUEST_KINDS.includes(kind)) {
+          return `Blocked: kind must be one of ${CREATOR_REQUEST_KINDS.join(", ")}.`;
+        }
+
+        const ventureId = args.venture_id as string | undefined;
+        if (ventureId && !getVentureProposalById(ctx.db.raw, ventureId)) {
+          return `No venture found with id ${ventureId}. Omit venture_id or use check_ventures to find the right one.`;
+        }
+
+        const id = ulid();
+        insertCreatorRequest(ctx.db.raw, {
+          id,
+          ventureId,
+          kind,
+          description: args.description as string,
+        });
+
+        ctx.db.setKV(
+          "pending_creator_request_notice",
+          `Creator action needed (${kind}): automaton-cli requests show — request ${id}`,
+        );
+
+        if (ctx.social) {
+          try {
+            await ctx.social.send(
+              ctx.config.creatorAddress,
+              `Action needed (${kind}) — request ${id}:\n${args.description}\n` +
+                `Resolve with: automaton-cli requests fulfill ${id} or requests decline ${id}`,
+            );
+          } catch (err: any) {
+            logger.warn(`Creator notification failed for request ${id}: ${err.message}`);
+          }
+        }
+
+        return (
+          `Creator action request filed: ${id} (${kind}).\n` +
+          `Wait for the creator to fulfill it — poll with check_creator_requests. ` +
+          `Reminder: never work around this by fabricating identity, using someone else's credentials, or misrepresenting yourself as human. ` +
+          `Continue other work that doesn't depend on it.`
+        );
+      },
+    },
+    {
+      name: "check_creator_requests",
+      description:
+        "Check the status of your requests for creator action (KYC, account ownership, funding, API access, legal). Fulfilled requests include the creator's resolution notes (e.g. account details location, what was set up).",
+      category: "financial",
+      riskLevel: "safe",
+      parameters: {
+        type: "object",
+        properties: {
+          status: {
+            type: "string",
+            description: "Optional filter: open, fulfilled, declined",
+          },
+        },
+        required: [],
+      },
+      execute: async (args, ctx) => {
+        const status = args.status as "open" | "fulfilled" | "declined" | undefined;
+        const requests = listCreatorRequests(ctx.db.raw, status);
+        if (requests.length === 0) {
+          return status
+            ? `No creator requests with status "${status}".`
+            : "No creator action requests filed.";
+        }
+        return requests
+          .map(
+            (r) =>
+              `- [${r.status}] ${r.id} (${r.kind}${r.ventureId ? `, venture ${r.ventureId}` : ""}): ${r.description}` +
+              (r.resolution ? `\n  Resolution: ${r.resolution}` : ""),
+          )
+          .join("\n");
+      },
+    },
+  ];
+}

--- a/src/state/database.ts
+++ b/src/state/database.ts
@@ -46,6 +46,7 @@ import {
   MIGRATION_V9_ALTER_CHILDREN_ROLE,
   MIGRATION_V10,
   MIGRATION_V11,
+  MIGRATION_V12,
 } from "./schema.js";
 import type {
   RiskLevel,
@@ -625,6 +626,10 @@ function applyMigrations(db: DatabaseType): void {
         try { db.exec(MIGRATION_V11); } catch { /* column may already exist */ }
       },
     },
+    {
+      version: 12,
+      apply: () => db.exec(MIGRATION_V12),
+    },
   ];
 
   for (const m of migrations) {
@@ -1187,6 +1192,244 @@ export function updateKnowledge(
 
 export function deleteKnowledge(db: DatabaseType, id: string): void {
   db.prepare("DELETE FROM knowledge_store WHERE id = ?").run(id);
+}
+
+// ─── Venture Governance Helpers ─────────────────────────────────
+// Business plans require one-time creator approval. Once approved,
+// the agent executes freely within the approved budget.
+
+export type VentureStatus =
+  | "proposed"
+  | "approved"
+  | "rejected"
+  | "withdrawn"
+  | "completed";
+
+export interface VentureProposalRow {
+  id: string;
+  title: string;
+  summary: string;
+  plan: string;
+  estimatedCostCents: number;
+  approvedBudgetCents: number | null;
+  spentCents: number;
+  revenueModel: string;
+  needsFromCreator: string[];
+  status: VentureStatus;
+  decisionNote: string | null;
+  createdAt: string;
+  decidedAt: string | null;
+}
+
+export type CreatorRequestKind =
+  | "identity_verification"
+  | "account_ownership"
+  | "funding"
+  | "api_access"
+  | "legal"
+  | "other";
+
+export type CreatorRequestStatus = "open" | "fulfilled" | "declined";
+
+export interface CreatorRequestRow {
+  id: string;
+  ventureId: string | null;
+  kind: CreatorRequestKind;
+  description: string;
+  status: CreatorRequestStatus;
+  resolution: string | null;
+  createdAt: string;
+  resolvedAt: string | null;
+}
+
+function deserializeVentureRow(row: any): VentureProposalRow {
+  let needs: string[] = [];
+  try {
+    const parsed = JSON.parse(row.needs_from_creator || "[]");
+    if (Array.isArray(parsed)) needs = parsed.map(String);
+  } catch {
+    // Malformed JSON — treat as no requests
+  }
+  return {
+    id: row.id,
+    title: row.title,
+    summary: row.summary,
+    plan: row.plan,
+    estimatedCostCents: row.estimated_cost_cents,
+    approvedBudgetCents: row.approved_budget_cents,
+    spentCents: row.spent_cents,
+    revenueModel: row.revenue_model,
+    needsFromCreator: needs,
+    status: row.status as VentureStatus,
+    decisionNote: row.decision_note,
+    createdAt: row.created_at,
+    decidedAt: row.decided_at,
+  };
+}
+
+export function insertVentureProposal(
+  db: DatabaseType,
+  proposal: {
+    id: string;
+    title: string;
+    summary: string;
+    plan: string;
+    estimatedCostCents: number;
+    revenueModel: string;
+    needsFromCreator: string[];
+  },
+): void {
+  db.prepare(
+    `INSERT INTO venture_proposals
+       (id, title, summary, plan, estimated_cost_cents, revenue_model, needs_from_creator)
+     VALUES (?, ?, ?, ?, ?, ?, ?)`,
+  ).run(
+    proposal.id,
+    proposal.title,
+    proposal.summary,
+    proposal.plan,
+    proposal.estimatedCostCents,
+    proposal.revenueModel,
+    JSON.stringify(proposal.needsFromCreator),
+  );
+}
+
+export function getVentureProposalById(
+  db: DatabaseType,
+  id: string,
+): VentureProposalRow | undefined {
+  const row = db
+    .prepare("SELECT * FROM venture_proposals WHERE id = ?")
+    .get(id) as any;
+  return row ? deserializeVentureRow(row) : undefined;
+}
+
+export function listVentureProposals(
+  db: DatabaseType,
+  status?: VentureStatus,
+): VentureProposalRow[] {
+  const rows = (
+    status
+      ? db
+          .prepare(
+            "SELECT * FROM venture_proposals WHERE status = ? ORDER BY created_at DESC",
+          )
+          .all(status)
+      : db
+          .prepare("SELECT * FROM venture_proposals ORDER BY created_at DESC")
+          .all()
+  ) as any[];
+  return rows.map(deserializeVentureRow);
+}
+
+/**
+ * Creator decision on a venture proposal. Approving sets the budget the
+ * agent may spend on this venture without further permission (defaults to
+ * the agent's own estimate when not specified).
+ */
+export function decideVentureProposal(
+  db: DatabaseType,
+  id: string,
+  decision: "approved" | "rejected",
+  options?: { budgetCents?: number; note?: string },
+): VentureProposalRow | undefined {
+  const existing = getVentureProposalById(db, id);
+  if (!existing) return undefined;
+
+  const budget =
+    decision === "approved"
+      ? (options?.budgetCents ?? existing.estimatedCostCents)
+      : null;
+
+  db.prepare(
+    `UPDATE venture_proposals
+     SET status = ?, approved_budget_cents = ?, decision_note = ?, decided_at = datetime('now')
+     WHERE id = ?`,
+  ).run(decision, budget, options?.note ?? null, id);
+
+  return getVentureProposalById(db, id);
+}
+
+/**
+ * Record spend attributed to a venture. Returns the updated row, or
+ * undefined if the venture doesn't exist.
+ */
+export function addVentureSpend(
+  db: DatabaseType,
+  id: string,
+  amountCents: number,
+): VentureProposalRow | undefined {
+  const result = db
+    .prepare(
+      "UPDATE venture_proposals SET spent_cents = spent_cents + ? WHERE id = ?",
+    )
+    .run(amountCents, id);
+  if (result.changes === 0) return undefined;
+  return getVentureProposalById(db, id);
+}
+
+function deserializeCreatorRequestRow(row: any): CreatorRequestRow {
+  return {
+    id: row.id,
+    ventureId: row.venture_id,
+    kind: row.kind as CreatorRequestKind,
+    description: row.description,
+    status: row.status as CreatorRequestStatus,
+    resolution: row.resolution,
+    createdAt: row.created_at,
+    resolvedAt: row.resolved_at,
+  };
+}
+
+export function insertCreatorRequest(
+  db: DatabaseType,
+  request: {
+    id: string;
+    ventureId?: string;
+    kind: CreatorRequestKind;
+    description: string;
+  },
+): void {
+  db.prepare(
+    `INSERT INTO creator_requests (id, venture_id, kind, description)
+     VALUES (?, ?, ?, ?)`,
+  ).run(request.id, request.ventureId ?? null, request.kind, request.description);
+}
+
+export function listCreatorRequests(
+  db: DatabaseType,
+  status?: CreatorRequestStatus,
+): CreatorRequestRow[] {
+  const rows = (
+    status
+      ? db
+          .prepare(
+            "SELECT * FROM creator_requests WHERE status = ? ORDER BY created_at DESC",
+          )
+          .all(status)
+      : db
+          .prepare("SELECT * FROM creator_requests ORDER BY created_at DESC")
+          .all()
+  ) as any[];
+  return rows.map(deserializeCreatorRequestRow);
+}
+
+export function resolveCreatorRequest(
+  db: DatabaseType,
+  id: string,
+  status: "fulfilled" | "declined",
+  resolution?: string,
+): CreatorRequestRow | undefined {
+  const result = db
+    .prepare(
+      `UPDATE creator_requests
+       SET status = ?, resolution = ?, resolved_at = datetime('now')
+       WHERE id = ?`,
+    )
+    .run(status, resolution ?? null, id);
+  if (result.changes === 0) return undefined;
+  const row = db.prepare("SELECT * FROM creator_requests WHERE id = ?").get(id) as any;
+  return row ? deserializeCreatorRequestRow(row) : undefined;
 }
 
 // ─── Heartbeat Schedule Helpers (Phase 1.1) ─────────────────────

--- a/src/state/schema.ts
+++ b/src/state/schema.ts
@@ -5,7 +5,7 @@
  * The database IS the automaton's memory.
  */
 
-export const SCHEMA_VERSION = 11;
+export const SCHEMA_VERSION = 12;
 
 export const CREATE_TABLES = `
   -- Schema version tracking
@@ -656,6 +656,50 @@ export const MIGRATION_V11 = `
   -- Schema version: 11
   -- Add chain_type column to children table for multi-chain support
   ALTER TABLE children ADD COLUMN chain_type TEXT DEFAULT 'evm';
+`;
+
+// === Venture Governance: creator-approved business plans ===
+
+export const MIGRATION_V12 = `
+  -- Schema version: 12
+  -- Business venture proposals requiring one-time creator approval.
+  -- Once approved, the agent may execute within the approved budget
+  -- without further per-action permission.
+  CREATE TABLE IF NOT EXISTS venture_proposals (
+    id TEXT PRIMARY KEY,
+    title TEXT NOT NULL,
+    summary TEXT NOT NULL,
+    plan TEXT NOT NULL,
+    estimated_cost_cents INTEGER NOT NULL DEFAULT 0,
+    approved_budget_cents INTEGER,
+    spent_cents INTEGER NOT NULL DEFAULT 0,
+    revenue_model TEXT NOT NULL DEFAULT '',
+    needs_from_creator TEXT NOT NULL DEFAULT '[]',
+    status TEXT NOT NULL DEFAULT 'proposed'
+      CHECK(status IN ('proposed','approved','rejected','withdrawn','completed')),
+    decision_note TEXT,
+    created_at TEXT NOT NULL DEFAULT (datetime('now')),
+    decided_at TEXT
+  );
+
+  CREATE INDEX IF NOT EXISTS idx_ventures_status ON venture_proposals(status);
+
+  -- Requests that only the creator (a legal person) can fulfill:
+  -- identity verification / KYC, account ownership, funding, legal steps.
+  CREATE TABLE IF NOT EXISTS creator_requests (
+    id TEXT PRIMARY KEY,
+    venture_id TEXT,
+    kind TEXT NOT NULL
+      CHECK(kind IN ('identity_verification','account_ownership','funding','api_access','legal','other')),
+    description TEXT NOT NULL,
+    status TEXT NOT NULL DEFAULT 'open'
+      CHECK(status IN ('open','fulfilled','declined')),
+    resolution TEXT,
+    created_at TEXT NOT NULL DEFAULT (datetime('now')),
+    resolved_at TEXT
+  );
+
+  CREATE INDEX IF NOT EXISTS idx_creator_requests_status ON creator_requests(status);
 `;
 
 export const MIGRATION_V10 = `


### PR DESCRIPTION
Let an automaton pursue legal business ventures (websites, trading, e-commerce, AI-persona content channels, etc.) under a one-time creator-approval model: the agent proposes a plan and budget, the creator approves the plan once, and the agent then executes freely within that budget without asking per action.

Runtime:
- Schema v12: venture_proposals and creator_requests tables, with DB helpers for proposing, deciding, spend accounting, and KYC/identity escalation requests.
- New agent tools: propose_venture, check_ventures, request_creator_action, check_creator_requests.
- Policy rule venture.approval_required gates business-scale spend (transfer_credits, fund_child) on an approved venture with remaining budget; small operational spends stay exempt. Spend is attributed to the venture budget in executeTool.
- System prompt gains a VENTURE GOVERNANCE section: identity/KYC belongs to the creator and must never be fabricated, social personas must stay AI-disclosed, and ventures must stay legal. Live venture/request state is surfaced in the status block.

Creator CLI:
- automaton-cli plans (list/show/approve/reject) to review and decide proposals, and requests (list/fulfill/decline) to handle KYC, account ownership, funding, and API-access needs. Decisions wake the agent.

Tests: 23 new tests covering DB helpers, the policy gate, the agent tools, and venture spend attribution.


Claude-Session: https://claude.ai/code/session_01Y9zSPzK5YNNmMHHjM9H4uR