### PR TITLE
fix: validate and escape commit hash in pull_upstream cherry-pick (CWE-78)

### DIFF
--- a/src/agent/tools.ts
+++ b/src/agent/tools.ts
@@ -645,7 +645,10 @@ export function createBuiltinTools(sandboxId: string): AutomatonTool[] {
         let appliedSummary: string;
         try {
           if (commit) {
-            await run(`git cherry-pick ${commit}`);
+            if (!/^[a-f0-9]{7,40}$/i.test(commit)) {
+              return `Blocked: invalid commit hash "${commit}"`;
+            }
+            await run(`git cherry-pick -- ${escapeShellArg(commit)}`);
             appliedSummary = `Cherry-picked ${commit}`;
           } else {
             await run("git pull origin main --ff-only");


### PR DESCRIPTION
## Summary

Fixes #180. The `pull_upstream` tool interpolated the `commit` parameter directly into `git cherry-pick ${commit}` with no execution-time validation or escaping. The policy engine's `validate.git_hash` rule covers the request layer, but a policy bypass or misconfigured rule would have exposed this injection point directly at the exec call.

## Fix

- Validate the commit hash format (`/^[a-f0-9]{7,40}$/i`) at execution time, returning a blocked message on mismatch.
- Wrap the value with the existing `escapeShellArg()` helper before interpolating into the shell command.

## Testing

- `tsc --noEmit` passes.
- Existing `command-injection.test.ts` policy-layer tests for `pull_upstream` still pass (71/71 in `tools-security.test.ts`, full suite green).