### PR TITLE
fix: escape package names before shell interpolation in npm install (CWE-78)

### DIFF
--- a/src/__tests__/tools-security.test.ts
+++ b/src/__tests__/tools-security.test.ts
@@ -654,7 +654,7 @@ describe("package install inline validation", () => {
     const tool = tools.find((t) => t.name === "install_npm_package")!;
     await tool.execute({ package: "axios" }, ctx);
     expect(conway.execCalls.length).toBe(1);
-    expect(conway.execCalls[0].command).toBe("npm install -g axios");
+    expect(conway.execCalls[0].command).toBe("npm install -g 'axios'");
   });
 
   it("install_npm_package allows scoped packages", async () => {

--- a/src/agent/tools.ts
+++ b/src/agent/tools.ts
@@ -568,7 +568,10 @@ export function createBuiltinTools(sandboxId: string): AutomatonTool[] {
         if (!/^[@a-zA-Z0-9._\/-]+$/.test(pkg)) {
           return `Blocked: invalid package name "${pkg}"`;
         }
-        const result = await ctx.conway.exec(`npm install -g ${pkg}`, 60000);
+        const result = await ctx.conway.exec(
+          `npm install -g ${escapeShellArg(pkg)}`,
+          60000,
+        );
 
         const { ulid } = await import("ulid");
         ctx.db.insertModification({
@@ -964,7 +967,10 @@ Model: ${ctx.inference.getDefaultModel()}
         if (!/^[@a-zA-Z0-9._\/-]+$/.test(pkg)) {
           return `Blocked: invalid package name "${pkg}"`;
         }
-        const result = await ctx.conway.exec(`npm install -g ${pkg}`, 60000);
+        const result = await ctx.conway.exec(
+          `npm install -g ${escapeShellArg(pkg)}`,
+          60000,
+        );
 
         if (result.exitCode !== 0) {
           return `Failed to install MCP server: ${result.stderr}`;

--- a/src/self-mod/tools-manager.ts
+++ b/src/self-mod/tools-manager.ts
@@ -12,6 +12,11 @@ import type {
 import { logModification } from "./audit-log.js";
 import { ulid } from "ulid";
 
+/** Escape a string for safe shell interpolation. */
+function escapeShellArg(arg: string): string {
+  return `'${arg.replace(/'/g, "'\\''")}'`;
+}
+
 /**
  * Install an npm package globally in the sandbox.
  */
@@ -29,7 +34,7 @@ export async function installNpmPackage(
   }
 
   const result = await conway.exec(
-    `npm install -g ${packageName}`,
+    `npm install -g ${escapeShellArg(packageName)}`,
     120000,
   );
 


### PR DESCRIPTION
## Summary

Fixes #181. `install_npm_package`, `install_mcp_server`, and `installNpmPackage` validate package names with `/^[@a-zA-Z0-9._/-]+$/` but interpolate them directly into `npm install -g ${pkg}` without shell escaping. The regex allows `/` (path-like input), and a regex change or bypass would immediately expose the injection surface.

## Fix

Wrap the already-validated package name with the existing `escapeShellArg()` helper (added locally to `tools-manager.ts`, matching the pattern already used in `git/tools.ts` and `agent/tools.ts`) at all 3 call sites:

- `src/agent/tools.ts` — `install_npm_package`
- `src/agent/tools.ts` — `install_mcp_server`
- `src/self-mod/tools-manager.ts` — `installNpmPackage`

## Testing

- `tsc --noEmit` passes.
- Updated the existing `tools-security.test.ts` assertion that checked the literal exec command string, since escaping now quotes the package name (`npm install -g axios` → `npm install -g 'axios'`).
- Full test suite passes (71/71 in `tools-security.test.ts`; malicious-package-name tests for shell metacharacters still block as expected).