### PR TITLE
fix: exclude dead workers from reassignment to break orchestrator deadlock

### DIFF
--- a/src/__tests__/orchestration/orchestrator.test.ts
+++ b/src/__tests__/orchestration/orchestrator.test.ts
@@ -78,6 +78,7 @@ function makeOrchestrator(
     inference?: ReturnType<typeof makeInference>;
     config?: any;
     messaging?: ColonyMessaging;
+    isWorkerAlive?: (address: string) => boolean;
   } = {},
 ): Orchestrator {
   const { messaging } = makeMessaging(db);
@@ -89,6 +90,7 @@ function makeOrchestrator(
     inference: overrides.inference ?? (makeInference() as any),
     identity: IDENTITY,
     config: overrides.config ?? {},
+    isWorkerAlive: overrides.isWorkerAlive,
   });
 }
 
@@ -421,6 +423,81 @@ describe("orchestration/Orchestrator", () => {
       expect(result.agentAddress).toBe(IDENTITY.address);
       expect(result.agentName).toBe(IDENTITY.name);
       expect(result.spawned).toBe(false);
+    });
+
+    it("does not reassign to a busy worker that isWorkerAlive reports as dead (#266/#259)", async () => {
+      const goalId = insertGoal(db);
+      // A 'running' child that is actually dead — e.g. its children row
+      // wasn't (yet) updated to 'dead' by the stale-recovery path.
+      db.prepare(
+        "INSERT INTO children (id, name, address, sandbox_id, genesis_prompt, creator_message, funded_amount_cents, status, created_at) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)",
+      ).run(ulid(), "DeadWorker", "local://dead-1", "sb-dead", "prompt", "msg", 0, "running", new Date().toISOString());
+
+      const agentTracker = makeAgentTracker({
+        getIdle: vi.fn().mockReturnValue([]),
+        getBestForTask: vi.fn().mockReturnValue(null),
+      });
+      const orc = makeOrchestrator(db, {
+        agentTracker,
+        config: { disableSpawn: true },
+        isWorkerAlive: (address) => address !== "local://dead-1",
+      });
+
+      // Previously findBusyAgentForReassign only excluded idle agents, so it
+      // would hand the task straight back to this dead worker, causing an
+      // infinite recover-reassign-die loop. It should now fall through to
+      // self-assignment instead.
+      const result = await orc.matchTaskToAgent(makeTask(goalId));
+      expect(result.agentAddress).not.toBe("local://dead-1");
+      expect(result.agentAddress).toBe(IDENTITY.address);
+    });
+  });
+
+  // ─── handleExecutingPhase: stale worker recovery ─────────────
+
+  describe("handleExecutingPhase stale worker recovery", () => {
+    it("marks a dead worker's children row dead and updates the tracker (#266/#259)", async () => {
+      const goalId = insertGoal(db, { status: "active" });
+      const deadWorkerAddress = "local://dead-worker";
+      const taskId = insertTask(db, {
+        goalId,
+        status: "assigned",
+        assignedTo: deadWorkerAddress,
+      });
+      db.prepare(
+        "INSERT INTO children (id, name, address, sandbox_id, genesis_prompt, creator_message, funded_amount_cents, status, created_at) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)",
+      ).run(ulid(), "DeadWorker", deadWorkerAddress, "sb-dead", "prompt", "msg", 0, "running", new Date().toISOString());
+      setOrchestratorState(db, { phase: "executing", goalId, replanCount: 0, failedTaskId: null, failedError: null });
+
+      const agentTracker = makeAgentTracker({
+        getIdle: vi.fn().mockReturnValue([]),
+        getBestForTask: vi.fn().mockReturnValue(null),
+      });
+      const orc = makeOrchestrator(db, {
+        agentTracker,
+        config: { disableSpawn: true },
+        isWorkerAlive: (address) => address !== deadWorkerAddress,
+      });
+
+      await orc.tick();
+
+      const taskRow = db.prepare("SELECT status, assigned_to FROM task_graph WHERE id = ?").get(taskId) as
+        | { status: string; assigned_to: string | null }
+        | undefined;
+      // The stale task is recovered off the dead worker. Since the dead
+      // worker is now excluded from reassignment, matchTaskToAgent falls
+      // through to self-assignment within the same tick — proving the
+      // fix breaks the recover-reassign-die loop rather than handing the
+      // task straight back to the same dead worker.
+      expect(taskRow?.assigned_to).not.toBe(deadWorkerAddress);
+
+      const childRow = db.prepare("SELECT status FROM children WHERE address = ?").get(deadWorkerAddress) as
+        | { status: string }
+        | undefined;
+      // ...and the dead worker is marked so it's excluded from future
+      // reassignment, breaking the recover-reassign-die loop.
+      expect(childRow?.status).toBe("dead");
+      expect(agentTracker.updateStatus).toHaveBeenCalledWith(deadWorkerAddress, "dead");
     });
   });
 

--- a/src/orchestration/orchestrator.ts
+++ b/src/orchestration/orchestrator.ts
@@ -543,6 +543,18 @@ export class Orchestrator {
           this.params.db.prepare(
             "UPDATE task_graph SET status = 'pending', assigned_to = NULL, started_at = NULL WHERE id = ?",
           ).run(task.id);
+
+          // Mark the dead worker so it's excluded from future reassignment.
+          // Without this, findBusyAgentForReassign() would hand the freed
+          // task straight back to the same dead worker (it only excludes
+          // idle agents, not dead ones), causing an infinite
+          // recover-reassign-die loop that never makes progress.
+          this.params.db.prepare(
+            `UPDATE children SET status = 'dead'
+             WHERE (sandbox_id = ? OR address = ?)
+               AND status NOT IN ('failed', 'dead', 'cleaned_up')`,
+          ).run(task.assignedTo, task.assignedTo);
+          this.params.agentTracker.updateStatus(task.assignedTo!, "dead");
         }
       }
     }
@@ -855,7 +867,15 @@ export class Orchestrator {
        ORDER BY created_at ASC`,
     ).all() as { name: string; address: string; status: string }[];
 
-    const candidate = rows.find((row) => !idleAddresses.has(row.address));
+    const candidate = rows.find((row) => {
+      if (idleAddresses.has(row.address)) return false;
+      // Defense-in-depth: never hand a task to a worker we know is dead,
+      // even if its `children` row wasn't (yet) updated to reflect that.
+      if (this.params.isWorkerAlive && !this.params.isWorkerAlive(row.address)) {
+        return false;
+      }
+      return true;
+    });
     if (!candidate) {
       return null;
     }


### PR DESCRIPTION
## Summary

Fixes #266, fixes #259. The orchestrator's stale-task recovery (`handleExecutingPhase`) resets a dead worker's task back to `pending` when `isWorkerAlive()` says the worker is gone — but never updates the worker's own status. Meanwhile `findBusyAgentForReassign()` only excludes **idle** agents when picking a busy worker to hand a freed task to, not dead ones. So the very next matching pass hands the recovered task straight back to the same dead worker. It dies again, gets "recovered" again, and reassigned again — an infinite recover-reassign-die loop that never completes the goal. That's what leaves `orchestrator.state` permanently stuck in `executing` and blocks all new goal creation (both #266 and #259 describe this from different angles — a low-RAM VM where workers OOM, and a stale `local://` worker after a restart).

## Fix

- When stale-task recovery detects a dead worker, mark its `children` row `'dead'` and call `agentTracker.updateStatus(address, "dead")`, so it's excluded from future reassignment.
- Defense-in-depth: `findBusyAgentForReassign()` now also checks the existing `isWorkerAlive()` hook directly, in case a task ever ends up assigned to a dead worker through some other path than the recovery block above.

## Testing

- `tsc --noEmit` passes.
- Added two regression tests:
  - `findBusyAgentForReassign` (via `matchTaskToAgent`) falls through to self-assignment rather than handing a task back to a worker `isWorkerAlive` reports dead.
  - The stale-task recovery path in `handleExecutingPhase` (via `tick()`) marks the dead worker's `children` row and tracker status, and — since the worker is now excluded — the same tick reassigns the freed task off it instead of looping back to it.
- Full orchestration test suite: 286/286 passing (`orchestrator.test.ts`, `messaging.test.ts`, `task-graph.test.ts`, `orchestrator-harness.test.ts`, `local-worker-harness.test.ts`, `attention.test.ts`, `workspace.test.ts`, `local-worker-security.test.ts`).