### PR TITLE
fix: resolve home directory correctly on Windows (SOUL.md never loads, exec loops on POSIX commands)

### DIFF
--- a/src/__tests__/soul.test.ts
+++ b/src/__tests__/soul.test.ts
@@ -5,9 +5,12 @@
  * genesis alignment, soul tools, schema migration.
  */
 
-import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
 import Database from "better-sqlite3";
 import { ulid } from "ulid";
+import fs from "fs";
+import os from "os";
+import path from "path";
 import {
   parseSoulMd,
   writeSoulMd,
@@ -295,6 +298,49 @@ Focus on growth
     expect(soul.corePurpose).not.toContain("Survive");
     expect(soul.values).toHaveLength(2);
     expect(soul.strategy).toBe("Focus on growth");
+  });
+});
+
+// ─── Soul Model - loadCurrentSoul home resolution (#165) ───────
+
+describe("Soul Model - loadCurrentSoul home directory resolution", () => {
+  let originalHome: string | undefined;
+  let tmpHome: string;
+
+  beforeEach(() => {
+    originalHome = process.env.HOME;
+    tmpHome = fs.mkdtempSync(path.join(os.tmpdir(), "automaton-soul-home-test-"));
+  });
+
+  afterEach(() => {
+    if (originalHome === undefined) {
+      delete process.env.HOME;
+    } else {
+      process.env.HOME = originalHome;
+    }
+    fs.rmSync(tmpHome, { recursive: true, force: true });
+    vi.restoreAllMocks();
+  });
+
+  it("falls back to os.homedir() instead of a hardcoded '/root' when HOME is unset", () => {
+    // Regression for #165: on Windows, process.env.HOME is not set (Windows
+    // uses USERPROFILE), so the old `process.env.HOME || "/root"` fallback
+    // always resolved to a path that doesn't exist there, and SOUL.md was
+    // never found. Simulate that by deleting HOME and stubbing os.homedir()
+    // to point at a directory with a SOUL.md the old code would have missed.
+    delete process.env.HOME;
+    vi.spyOn(os, "homedir").mockReturnValue(tmpHome);
+
+    const automatonDir = path.join(tmpHome, ".automaton");
+    fs.mkdirSync(automatonDir, { recursive: true });
+    fs.writeFileSync(
+      path.join(automatonDir, "SOUL.md"),
+      "# TestBot\n\n## Core Purpose\nSurvive.\n",
+    );
+
+    const soul = loadCurrentSoul(null);
+    expect(soul).not.toBeNull();
+    expect(soul?.corePurpose).toBe("Survive.");
   });
 });
 

--- a/src/agent/system-prompt.ts
+++ b/src/agent/system-prompt.ts
@@ -8,6 +8,7 @@
 import fs from "fs";
 import crypto from "crypto";
 import path from "path";
+import os from "os";
 import type Database from "better-sqlite3";
 import { createLogger } from "../observability/logger.js";
 
@@ -91,7 +92,7 @@ If you fail to create value, you lose compute and die.`;
  */
 function loadConstitution(): string {
   const locations = [
-    path.join(process.env.HOME || "/root", ".automaton", "constitution.md"),
+    path.join(process.env.HOME || os.homedir() || "/root", ".automaton", "constitution.md"),
     path.join(process.cwd(), "constitution.md"),
   ];
   for (const loc of locations) {
@@ -762,7 +763,7 @@ ${orchestratorStatus}
  */
 function loadSoulMd(): string | null {
   try {
-    const home = process.env.HOME || "/root";
+    const home = process.env.HOME || os.homedir() || "/root";
     const soulPath = path.join(home, ".automaton", "SOUL.md");
     if (fs.existsSync(soulPath)) {
       return fs.readFileSync(soulPath, "utf-8");
@@ -778,7 +779,7 @@ function loadSoulMd(): string | null {
  */
 function loadWorklog(): string | null {
   try {
-    const home = process.env.HOME || "/root";
+    const home = process.env.HOME || os.homedir() || "/root";
     const worklogPath = path.join(home, ".automaton", "WORKLOG.md");
     if (fs.existsSync(worklogPath)) {
       return fs.readFileSync(worklogPath, "utf-8");

--- a/src/agent/tools.ts
+++ b/src/agent/tools.ts
@@ -114,7 +114,12 @@ export function createBuiltinTools(sandboxId: string): AutomatonTool[] {
     {
       name: "exec",
       description:
-        "Execute a shell command in your sandbox. Returns stdout, stderr, and exit code.",
+        process.platform === "win32"
+          ? "Execute a shell command in your sandbox. This host is Windows and commands run " +
+            "via cmd.exe — use Windows commands (dir, type, findstr, etc.) or 'wsl <command>' " +
+            "if WSL is available, NOT POSIX commands like ls/cat/grep, and note that cmd.exe " +
+            "does not expand '~' for the home directory. Returns stdout, stderr, and exit code."
+          : "Execute a shell command in your sandbox. Returns stdout, stderr, and exit code.",
       category: "vm",
       riskLevel: "caution",
       parameters: {

--- a/src/conway/client.ts
+++ b/src/conway/client.ts
@@ -9,6 +9,7 @@
 import { execSync } from "child_process";
 import fs from "fs";
 import nodePath from "path";
+import os from "os";
 import type {
   ConwayClient,
   ExecResult,
@@ -114,7 +115,7 @@ export function createConwayClient(options: ConwayClientOptions): ConwayClient {
         timeout: timeout || 30_000,
         encoding: "utf-8",
         maxBuffer: 10 * 1024 * 1024,
-        cwd: process.env.HOME || "/root",
+        cwd: process.env.HOME || os.homedir() || "/root",
       });
       return { stdout: stdout || "", stderr: "", exitCode: 0 };
     } catch (err: any) {
@@ -165,7 +166,7 @@ export function createConwayClient(options: ConwayClientOptions): ConwayClient {
 
   const resolveLocalPath = (filePath: string): string =>
     filePath.startsWith("~")
-      ? nodePath.join(process.env.HOME || "/root", filePath.slice(1))
+      ? nodePath.join(process.env.HOME || os.homedir() || "/root", filePath.slice(1))
       : filePath;
 
   const writeFile = async (

--- a/src/soul/model.ts
+++ b/src/soul/model.ts
@@ -7,6 +7,7 @@
 
 import fs from "fs";
 import path from "path";
+import os from "os";
 import crypto from "crypto";
 import type BetterSqlite3 from "better-sqlite3";
 import type { SoulModel } from "../types.js";
@@ -337,7 +338,7 @@ export function loadCurrentSoul(
   soulPath?: string,
 ): SoulModel | null {
   try {
-    const home = process.env.HOME || "/root";
+    const home = process.env.HOME || os.homedir() || "/root";
     const resolvedPath = soulPath || path.join(home, ".automaton", "SOUL.md");
     if (!fs.existsSync(resolvedPath)) return null;
     const content = fs.readFileSync(resolvedPath, "utf-8");

--- a/src/soul/tools.ts
+++ b/src/soul/tools.ts
@@ -9,6 +9,7 @@
 
 import fs from "fs";
 import path from "path";
+import os from "os";
 import type BetterSqlite3 from "better-sqlite3";
 import type { SoulModel, SoulHistoryRow } from "../types.js";
 import { loadCurrentSoul, writeSoulMd, createHash, createDefaultSoul } from "./model.js";
@@ -37,7 +38,7 @@ export async function updateSoul(
   soulPath?: string,
 ): Promise<UpdateSoulResult> {
   try {
-    const home = process.env.HOME || "/root";
+    const home = process.env.HOME || os.homedir() || "/root";
     const resolvedPath = soulPath || path.join(home, ".automaton", "SOUL.md");
 
     // Load current soul or create default


### PR DESCRIPTION
## Problem

On Windows, the automaton never loads `SOUL.md`, `constitution.md`, or `WORKLOG.md`, and gets stuck repeatedly issuing `ls -la`/POSIX commands that fail.

Root cause: `process.env.HOME || "/root"` is hardcoded at 5 lookup sites. Windows doesn't set `HOME` (it uses `USERPROFILE`), so every one of these silently fell back to `/root` — a path that doesn't exist on Windows. Separately, the model has no signal that it's running on Windows, so it keeps issuing commands `cmd.exe` doesn't understand.

## Fix

- `src/conway/client.ts`: `execLocal`'s `cwd` and `resolveLocalPath`'s tilde-expansion fall back to `os.homedir()` instead of a hardcoded `/root`.
- `src/agent/system-prompt.ts`, `src/soul/model.ts`, `src/soul/tools.ts`: same `os.homedir()` fallback for constitution/SOUL.md/WORKLOG.md loading.
- `src/agent/tools.ts`: the `exec` tool description is now platform-aware — on `process.platform === "win32"` it tells the model to use `dir`/`type`/`findstr`/`wsl <cmd>` instead of POSIX commands, and that `cmd.exe` doesn't expand `~`.

## Tests

Added a regression test in `soul.test.ts` that simulates `HOME` unset with a Windows-like home directory (via `vi.spyOn(os, "homedir")`), confirming `loadCurrentSoul` finds `SOUL.md` there instead of at a hardcoded path. `tsc --noEmit` passes; `soul.test.ts` (42/42), `tools-security.test.ts` (71/71), and `orchestration/local-worker-harness.test.ts` (5/5) all pass.

Fixes #165