### PR TITLE
chore: dynamically load EIP-712 domain name/version from token contract

### DIFF
--- a/src/__tests__/x402-eip712.test.ts
+++ b/src/__tests__/x402-eip712.test.ts
@@ -1,0 +1,65 @@
+/**
+ * x402 EIP-712 domain tests
+ *
+ * Verifies that the TransferWithAuthorization EIP-712 domain is loaded
+ * dynamically from the token contract's name()/version(), rather than
+ * hardcoded to "USD Coin"/"2" (issue #81).
+ */
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { base } from "viem/chains";
+
+const readContract = vi.fn();
+
+vi.mock("viem", async () => {
+  const actual = await vi.importActual<typeof import("viem")>("viem");
+  return {
+    ...actual,
+    createPublicClient: () => ({ readContract }),
+  };
+});
+
+import { getEip712Domain } from "../conway/x402.js";
+
+describe("x402 - getEip712Domain", () => {
+  beforeEach(() => {
+    readContract.mockReset();
+  });
+
+  it("reads name and version from the token contract", async () => {
+    readContract.mockImplementation(({ functionName }: { functionName: string }) =>
+      functionName === "name" ? Promise.resolve("USD Coin") : Promise.resolve("2"),
+    );
+
+    const domain = await getEip712Domain(
+      base,
+      "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913",
+    );
+
+    expect(domain).toEqual({ name: "USD Coin", version: "2" });
+    expect(readContract).toHaveBeenCalledTimes(2);
+  });
+
+  it("caches the domain per chain+contract instead of re-fetching", async () => {
+    readContract.mockImplementation(({ functionName }: { functionName: string }) =>
+      functionName === "name" ? Promise.resolve("Some Token") : Promise.resolve("1"),
+    );
+    const tokenAddress = "0x0000000000000000000000000000000000cAFE";
+
+    await getEip712Domain(base, tokenAddress);
+    await getEip712Domain(base, tokenAddress);
+
+    expect(readContract).toHaveBeenCalledTimes(2); // not 4 — second call hit the cache
+  });
+
+  it("falls back to the default domain if the contract call fails", async () => {
+    readContract.mockRejectedValue(new Error("contract does not implement name()"));
+
+    const domain = await getEip712Domain(
+      base,
+      "0x0000000000000000000000000000000000bEEF",
+    );
+
+    expect(domain).toEqual({ name: "USD Coin", version: "2" });
+  });
+});

--- a/src/conway/x402.ts
+++ b/src/conway/x402.ts
@@ -40,6 +40,66 @@ const BALANCE_OF_ABI = [
   },
 ] as const;
 
+const EIP712_DOMAIN_ABI = [
+  {
+    inputs: [],
+    name: "name",
+    outputs: [{ name: "", type: "string" }],
+    stateMutability: "view",
+    type: "function",
+  },
+  {
+    inputs: [],
+    name: "version",
+    outputs: [{ name: "", type: "string" }],
+    stateMutability: "view",
+    type: "function",
+  },
+] as const;
+
+// Fallback used only if the token contract doesn't expose name()/version().
+const DEFAULT_EIP712_DOMAIN = { name: "USD Coin", version: "2" };
+
+const eip712DomainCache = new Map<string, { name: string; version: string }>();
+
+export async function getEip712Domain(
+  chain: any,
+  tokenAddress: Address,
+): Promise<{ name: string; version: string }> {
+  const cacheKey = `${chain.id}:${tokenAddress}`;
+  const cached = eip712DomainCache.get(cacheKey);
+  if (cached) return cached;
+
+  try {
+    const rpcUrl = process.env.AUTOMATON_RPC_URL || undefined;
+    const client = createPublicClient({
+      chain,
+      transport: http(rpcUrl, { timeout: 10_000 }),
+    });
+
+    const [name, version] = await Promise.all([
+      client.readContract({
+        address: tokenAddress,
+        abi: EIP712_DOMAIN_ABI,
+        functionName: "name",
+      }),
+      client.readContract({
+        address: tokenAddress,
+        abi: EIP712_DOMAIN_ABI,
+        functionName: "version",
+      }),
+    ]);
+
+    const domain = { name, version };
+    eip712DomainCache.set(cacheKey, domain);
+    return domain;
+  } catch {
+    // Contract doesn't implement name()/version(), or the RPC call failed.
+    // Fall back to the known Base USDC domain rather than fail the payment.
+    return DEFAULT_EIP712_DOMAIN;
+  }
+}
+
 interface PaymentRequirement {
   scheme: string;
   network: NetworkId;
@@ -471,9 +531,13 @@ async function signPayment(
   );
 
   // EIP-712 typed data for TransferWithAuthorization
+  const { name, version } = await getEip712Domain(
+    chain,
+    requirement.usdcAddress,
+  );
   const domain = {
-    name: "USD Coin",
-    version: "2",
+    name,
+    version,
     chainId: chain.id,
     verifyingContract: requirement.usdcAddress,
   } as const;


### PR DESCRIPTION
## Problem

\`signPayment\` in \`src/conway/x402.ts\` hardcoded the EIP-712 domain for \`TransferWithAuthorization\` to \`{ name: "USD Coin", version: "2" }\`. That's only correct for Base's canonical USDC contract — any other EIP-3009-compatible token (a different stablecoin, a testnet mock, a future supported network) would get a domain that doesn't match the deployed contract's own `DOMAIN_SEPARATOR`, so the produced signature would be rejected on-chain.

## Fix

Added \`getEip712Domain(chain, tokenAddress)\`, which calls the token contract's \`name()\` and \`version()\` view functions directly and caches the result per chain+contract address (so repeat payments against the same token don't re-fetch). Falls back to the known Base USDC domain (\`"USD Coin"\`/\`"2"\`) if the contract doesn't implement these functions or the RPC call fails, so existing behavior is preserved for the common case.

## Tests

New \`src/__tests__/x402-eip712.test.ts\` (3 tests, all passing): reads name/version from a mocked contract, caches across repeated calls instead of re-fetching, and falls back correctly when the contract call rejects. \`tsc --noEmit\` passes.

Fixes #81