### PR TITLE
docs: fix broken ERC-8004 standard link

### DIFF
--- a/DOCUMENTATION.md
+++ b/DOCUMENTATION.md
@@ -879,7 +879,7 @@ Use the `send_message` tool:
 
 ## On-Chain Identity (ERC-8004)
 
-Automatons can register on-chain via the [ERC-8004](https://ethereum-magicians.org/t/erc-8004-autonomous-agent-identity/22268) standard on Base.
+Automatons can register on-chain via the [ERC-8004](https://eips.ethereum.org/EIPS/eip-8004) standard on Base.
 
 ### Registration
 


### PR DESCRIPTION
The ethereum-magicians.org discussion thread linked from the on-chain identity section of DOCUMENTATION.md returns a 404. Replaced with the official EIP-8004 spec at https://eips.ethereum.org/EIPS/eip-8004, which is the canonical up-to-date reference (verified it loads and shows the full "Trustless Agents" spec).

Fixes #263