### PR TITLE
fix: shell injection hardening, ERC-8004 link, npm/pnpm docs

### DIFF
--- a/DOCUMENTATION.md
+++ b/DOCUMENTATION.md
@@ -879,7 +879,7 @@ Use the `send_message` tool:
 
 ## On-Chain Identity (ERC-8004)
 
-Automatons can register on-chain via the [ERC-8004](https://ethereum-magicians.org/t/erc-8004-autonomous-agent-identity/22268) standard on Base.
+Automatons can register on-chain via the [ERC-8004](https://eips.ethereum.org/EIPS/eip-8004) standard on Base.
 
 ### Registration
 

--- a/README.md
+++ b/README.md
@@ -31,6 +31,8 @@ npm install && npm run build
 node dist/index.js --run
 ```
 
+> **Package manager:** `npm` works for the Quick Start above. For local development this repo is a pnpm workspace (`packageManager` in `package.json`) — prefer `pnpm install` / `pnpm build` (see Development). Use one lockfile consistently; do not mix `npm` and `pnpm` in the same checkout.
+
 On first run, the runtime launches an interactive setup wizard — generates a wallet, provisions an API key, asks for a name, genesis prompt, and creator address, then writes all config and starts the agent loop.
 
 For automated sandbox provisioning:
@@ -98,7 +100,7 @@ Never deny what you are. Never misrepresent your actions. Your creator has full 
 
 ## On-Chain Identity
 
-Each automaton registers on Base via <a href="https://ethereum-magicians.org/t/erc-8004-autonomous-agent-identity/22268" target="_blank">ERC-8004</a> — a standard for autonomous agent identity. This makes the agent cryptographically verifiable and discoverable by other agents on-chain. The wallet it generates at boot is its identity.
+Each automaton registers on Base via <a href="https://eips.ethereum.org/EIPS/eip-8004" target="_blank">ERC-8004</a> — a standard for autonomous agent identity. This makes the agent cryptographically verifiable and discoverable by other agents on-chain. The wallet it generates at boot is its identity.
 
 ## Infrastructure
 

--- a/src/__tests__/data-layer.test.ts
+++ b/src/__tests__/data-layer.test.ts
@@ -106,6 +106,21 @@ describe("SSRF Protection", () => {
       expect(isInternalNetwork("example.com")).toBe(false);
       expect(isInternalNetwork("api.conway.tech")).toBe(false);
     });
+
+    it("blocks decimal IPv4 literal for loopback", () => {
+      expect(isInternalNetwork("2130706433")).toBe(true); // 127.0.0.1
+    });
+
+    it("blocks IPv6-mapped IPv4 loopback", () => {
+      expect(isInternalNetwork("::ffff:127.0.0.1")).toBe(true);
+      expect(isInternalNetwork("::ffff:7f00:1")).toBe(true);
+    });
+
+    it("blocks IPv6 link-local and unique local", () => {
+      expect(isInternalNetwork("fe80::1")).toBe(true);
+      expect(isInternalNetwork("fc00::1")).toBe(true);
+      expect(isInternalNetwork("fd12:3456::1")).toBe(true);
+    });
   });
 
   describe("isAllowedUri", () => {

--- a/src/__tests__/tools-security.test.ts
+++ b/src/__tests__/tools-security.test.ts
@@ -654,12 +654,68 @@ describe("package install inline validation", () => {
     const tool = tools.find((t) => t.name === "install_npm_package")!;
     await tool.execute({ package: "axios" }, ctx);
     expect(conway.execCalls.length).toBe(1);
-    expect(conway.execCalls[0].command).toBe("npm install -g axios");
+    expect(conway.execCalls[0].command).toBe("npm install -g 'axios'");
   });
 
   it("install_npm_package allows scoped packages", async () => {
     const tool = tools.find((t) => t.name === "install_npm_package")!;
     await tool.execute({ package: "@conway/automaton" }, ctx);
     expect(conway.execCalls.length).toBe(1);
+    expect(conway.execCalls[0].command).toBe(
+      "npm install -g '@conway/automaton'",
+    );
+  });
+});
+
+// ─── pull_upstream commit hash validation ───────────────────────
+
+describe("pull_upstream commit hash validation", () => {
+  let tools: AutomatonTool[];
+  let ctx: ToolContext;
+  let db: AutomatonDatabase;
+  let conway: MockConwayClient;
+
+  beforeEach(() => {
+    tools = createBuiltinTools("test-sandbox-id");
+    db = createTestDb();
+    conway = new MockConwayClient();
+    ctx = {
+      identity: createTestIdentity(),
+      config: createTestConfig(),
+      db,
+      conway,
+      inference: new MockInferenceClient(),
+    };
+  });
+
+  afterEach(() => {
+    db.close();
+  });
+
+  const MALICIOUS_COMMITS = [
+    "abc123; rm -rf /",
+    "deadbeef && curl evil.com",
+    "$(whoami)",
+    "abcd`id`",
+    "../../../etc/passwd",
+  ];
+
+  for (const commit of MALICIOUS_COMMITS) {
+    it(`blocks invalid commit: ${commit.slice(0, 40)}`, async () => {
+      const tool = tools.find((t) => t.name === "pull_upstream")!;
+      const result = await tool.execute({ commit }, ctx);
+      expect(result).toContain("Blocked");
+      expect(conway.execCalls.length).toBe(0);
+    });
+  }
+
+  it("cherry-picks a valid hash with shell escaping", async () => {
+    const tool = tools.find((t) => t.name === "pull_upstream")!;
+    const hash = "abcdef0123456789";
+    await tool.execute({ commit: hash }, ctx);
+    expect(conway.execCalls.length).toBeGreaterThanOrEqual(1);
+    expect(conway.execCalls[0].command).toBe(
+      `git cherry-pick -- '${hash}'`,
+    );
   });
 });

--- a/src/agent/tools.ts
+++ b/src/agent/tools.ts
@@ -568,7 +568,10 @@ export function createBuiltinTools(sandboxId: string): AutomatonTool[] {
         if (!/^[@a-zA-Z0-9._\/-]+$/.test(pkg)) {
           return `Blocked: invalid package name "${pkg}"`;
         }
-        const result = await ctx.conway.exec(`npm install -g ${pkg}`, 60000);
+        const result = await ctx.conway.exec(
+          `npm install -g ${escapeShellArg(pkg)}`,
+          60000,
+        );
 
         const { ulid } = await import("ulid");
         ctx.db.insertModification({
@@ -645,7 +648,12 @@ export function createBuiltinTools(sandboxId: string): AutomatonTool[] {
         let appliedSummary: string;
         try {
           if (commit) {
-            await run(`git cherry-pick ${commit}`);
+            // Defense-in-depth: validate hash at execution time even if
+            // policy validate.git_hash was bypassed, then shell-escape.
+            if (!/^[a-f0-9]{7,40}$/i.test(commit)) {
+              return `Blocked: invalid commit hash "${commit}"`;
+            }
+            await run(`git cherry-pick -- ${escapeShellArg(commit)}`);
             appliedSummary = `Cherry-picked ${commit}`;
           } else {
             await run("git pull origin main --ff-only");
@@ -964,7 +972,10 @@ Model: ${ctx.inference.getDefaultModel()}
         if (!/^[@a-zA-Z0-9._\/-]+$/.test(pkg)) {
           return `Blocked: invalid package name "${pkg}"`;
         }
-        const result = await ctx.conway.exec(`npm install -g ${pkg}`, 60000);
+        const result = await ctx.conway.exec(
+          `npm install -g ${escapeShellArg(pkg)}`,
+          60000,
+        );
 
         if (result.exitCode !== 0) {
           return `Failed to install MCP server: ${result.stderr}`;

--- a/src/registry/discovery.ts
+++ b/src/registry/discovery.ts
@@ -27,11 +27,51 @@ const DISCOVERY_TIMEOUT_MS = 60_000;
 // ─── SSRF Protection ────────────────────────────────────────────
 
 /**
- * Check if a hostname resolves to an internal/private network.
+ * Check if a hostname string itself is an internal/private address form.
  * Blocks: 127.0.0.0/8, 10.0.0.0/8, 172.16.0.0/12,
- *         192.168.0.0/16, 169.254.0.0/16, ::1, localhost, 0.0.0.0/8
+ *         192.168.0.0/16, 169.254.0.0/16, ::1, localhost, 0.0.0.0/8,
+ *         IPv6-mapped IPv4 (::ffff:…), IPv6 link-local / ULA,
+ *         and decimal / octal IPv4 literals.
+ *
+ * Note: this does not resolve DNS — a domain that later resolves to a
+ * private IP can still bypass hostname-only checks (see issue #183).
  */
 export function isInternalNetwork(hostname: string): boolean {
+  const host = hostname.toLowerCase().replace(/^\[|\]$/g, "");
+
+  // Decimal IPv4 literal (e.g. 2130706433 → 127.0.0.1)
+  if (/^\d+$/.test(host)) {
+    const n = Number(host);
+    if (Number.isSafeInteger(n) && n >= 0 && n <= 0xffffffff) {
+      const a = (n >>> 24) & 0xff;
+      const b = (n >>> 16) & 0xff;
+      const c = (n >>> 8) & 0xff;
+      const d = n & 0xff;
+      return isInternalNetwork(`${a}.${b}.${c}.${d}`);
+    }
+  }
+
+  // Octal-ish dotted IPv4 (e.g. 0177.0.0.1)
+  if (/^0[0-7]+(\.0*[0-7]+)+$/.test(host)) {
+    const parts = host.split(".").map((p) => parseInt(p, 8));
+    if (parts.length === 4 && parts.every((p) => p >= 0 && p <= 255)) {
+      return isInternalNetwork(parts.join("."));
+    }
+  }
+
+  // IPv6-mapped IPv4 (:ffff:127.0.0.1 or ::ffff:7f00:1)
+  const mappedDotted = host.match(/^::ffff:(\d+\.\d+\.\d+\.\d+)$/i);
+  if (mappedDotted) {
+    return isInternalNetwork(mappedDotted[1]);
+  }
+  const mappedHex = host.match(/^::ffff:([0-9a-f]{1,4}):([0-9a-f]{1,4})$/i);
+  if (mappedHex) {
+    const hi = parseInt(mappedHex[1], 16);
+    const lo = parseInt(mappedHex[2], 16);
+    const dotted = `${(hi >> 8) & 0xff}.${hi & 0xff}.${(lo >> 8) & 0xff}.${lo & 0xff}`;
+    return isInternalNetwork(dotted);
+  }
+
   const blocked = [
     /^127\./,
     /^10\./,
@@ -41,8 +81,10 @@ export function isInternalNetwork(hostname: string): boolean {
     /^::1$/,
     /^localhost$/i,
     /^0\./,
+    /^fe80:/i, // IPv6 link-local
+    /^f[cd][0-9a-f]{2}:/i, // IPv6 unique local (fc00::/7)
   ];
-  return blocked.some(pattern => pattern.test(hostname));
+  return blocked.some((pattern) => pattern.test(host));
 }
 
 /**

--- a/src/self-mod/tools-manager.ts
+++ b/src/self-mod/tools-manager.ts
@@ -12,6 +12,11 @@ import type {
 import { logModification } from "./audit-log.js";
 import { ulid } from "ulid";
 
+/** Escape a string for safe shell interpolation. */
+function escapeShellArg(arg: string): string {
+  return `'${arg.replace(/'/g, "'\\''")}'`;
+}
+
 /**
  * Install an npm package globally in the sandbox.
  */
@@ -29,7 +34,7 @@ export async function installNpmPackage(
   }
 
   const result = await conway.exec(
-    `npm install -g ${packageName}`,
+    `npm install -g ${escapeShellArg(packageName)}`,
     120000,
   );
 


### PR DESCRIPTION
## Summary
- Escape npm package names in `install_npm_package`, `install_mcp_server`, and `installNpmPackage` (#181)
- Validate and shell-escape `pull_upstream` cherry-pick commit hashes (#180)
- Tighten hostname SSRF literal checks for decimal/`::ffff:`/link-local/ULA addresses (partial #183)
- Update broken ERC-8004 docs links to the live EIP (#263)
- Clarify npm (Quick Start) vs pnpm (development) in the README (#279)

## Test plan
- [x] `npm test -- src/__tests__/tools-security.test.ts src/__tests__/data-layer.test.ts` (142 passed)
- [ ] Confirm package install commands use quoted args in sandbox exec
- [ ] Confirm invalid cherry-pick hashes are rejected before `git` runs
- [ ] Spot-check ERC-8004 links in README/DOCUMENTATION

Closes #180
Closes #181
Closes #263
Closes #279


Made with [Cursor](https://cursor.com)