### PR TITLE
fix(tests): use fileURLToPath so source-safety specs pass on checkout paths with spaces

### DIFF
--- a/src/__tests__/command-injection.test.ts
+++ b/src/__tests__/command-injection.test.ts
@@ -12,6 +12,7 @@
  */
 
 import { describe, it, expect } from "vitest";
+import { fileURLToPath } from "node:url";
 import { createDefaultRules } from "../agent/policy-rules/index.js";
 import { createValidationRules } from "../agent/policy-rules/validation.js";
 import { createCommandSafetyRules } from "../agent/policy-rules/command-safety.js";
@@ -558,7 +559,7 @@ describe("Source code injection safety", () => {
   it("upstream.ts uses execFileSync not execSync with string interpolation", async () => {
     const fs = await import("fs");
     const source = fs.readFileSync(
-      new URL("../self-mod/upstream.ts", import.meta.url).pathname.replace("/src/__tests__/../", "/src/"),
+      fileURLToPath(new URL("../self-mod/upstream.ts", import.meta.url)),
       "utf-8",
     );
     // Should NOT have: execSync(`git ${cmd}`)
@@ -570,7 +571,7 @@ describe("Source code injection safety", () => {
   it("registry.ts uses execFileSync not conway.exec with interpolation", async () => {
     const fs = await import("fs");
     const source = fs.readFileSync(
-      new URL("../skills/registry.ts", import.meta.url).pathname.replace("/src/__tests__/../", "/src/"),
+      fileURLToPath(new URL("../skills/registry.ts", import.meta.url)),
       "utf-8",
     );
     // Should NOT have template literals in conway.exec calls
@@ -584,7 +585,7 @@ describe("Source code injection safety", () => {
   it("loader.ts uses execFileSync('which', [bin]) not execSync('which ${bin}')", async () => {
     const fs = await import("fs");
     const source = fs.readFileSync(
-      new URL("../skills/loader.ts", import.meta.url).pathname.replace("/src/__tests__/../", "/src/"),
+      fileURLToPath(new URL("../skills/loader.ts", import.meta.url)),
       "utf-8",
     );
     // Should NOT have: execSync(`which ${bin}`)
@@ -596,7 +597,7 @@ describe("Source code injection safety", () => {
   it("tools.ts pull_upstream uses conway.exec not host execSync", async () => {
     const fs = await import("fs");
     const source = fs.readFileSync(
-      new URL("../agent/tools.ts", import.meta.url).pathname.replace("/src/__tests__/../", "/src/"),
+      fileURLToPath(new URL("../agent/tools.ts", import.meta.url)),
       "utf-8",
     );
     // Find the pull_upstream section and check it doesn't import child_process
@@ -611,7 +612,7 @@ describe("Source code injection safety", () => {
   it("tools.ts has defense-in-depth comment on FORBIDDEN_COMMAND_PATTERNS", async () => {
     const fs = await import("fs");
     const source = fs.readFileSync(
-      new URL("../agent/tools.ts", import.meta.url).pathname.replace("/src/__tests__/../", "/src/"),
+      fileURLToPath(new URL("../agent/tools.ts", import.meta.url)),
       "utf-8",
     );
     expect(source).toMatch(/[Dd]efense.in.depth.*policy engine/i);

--- a/src/__tests__/skills-hardening.test.ts
+++ b/src/__tests__/skills-hardening.test.ts
@@ -12,6 +12,7 @@
  */
 
 import { describe, it, expect, vi } from "vitest";
+import { fileURLToPath } from "node:url";
 import { getActiveSkillInstructions } from "../skills/loader.js";
 import { parseSkillMd } from "../skills/format.js";
 import type { Skill } from "../types.js";
@@ -209,7 +210,7 @@ describe("skills/registry.ts validation", () => {
   it("createSkill uses yaml.stringify for safe frontmatter generation", async () => {
     const fs = await import("fs");
     const source = fs.readFileSync(
-      new URL("../skills/registry.ts", import.meta.url).pathname.replace("/src/__tests__/../", "/src/"),
+      fileURLToPath(new URL("../skills/registry.ts", import.meta.url)),
       "utf-8",
     );
     expect(source).toMatch(/yaml\.stringify\s*\(/);
@@ -220,7 +221,7 @@ describe("skills/registry.ts validation", () => {
   it("registry has path traversal validation function", async () => {
     const fs = await import("fs");
     const source = fs.readFileSync(
-      new URL("../skills/registry.ts", import.meta.url).pathname.replace("/src/__tests__/../", "/src/"),
+      fileURLToPath(new URL("../skills/registry.ts", import.meta.url)),
       "utf-8",
     );
     expect(source).toMatch(/validateSkillPath/);
@@ -231,7 +232,7 @@ describe("skills/registry.ts validation", () => {
   it("createSkill enforces description size limit", async () => {
     const fs = await import("fs");
     const source = fs.readFileSync(
-      new URL("../skills/registry.ts", import.meta.url).pathname.replace("/src/__tests__/../", "/src/"),
+      fileURLToPath(new URL("../skills/registry.ts", import.meta.url)),
       "utf-8",
     );
     expect(source).toMatch(/MAX_DESCRIPTION_LENGTH/);
@@ -241,7 +242,7 @@ describe("skills/registry.ts validation", () => {
   it("createSkill enforces instructions size limit", async () => {
     const fs = await import("fs");
     const source = fs.readFileSync(
-      new URL("../skills/registry.ts", import.meta.url).pathname.replace("/src/__tests__/../", "/src/"),
+      fileURLToPath(new URL("../skills/registry.ts", import.meta.url)),
       "utf-8",
     );
     expect(source).toMatch(/MAX_INSTRUCTIONS_LENGTH/);
@@ -261,7 +262,7 @@ describe("skills/registry.ts validation", () => {
   it("YAML injection via description is prevented", async () => {
     const fs = await import("fs");
     const source = fs.readFileSync(
-      new URL("../skills/registry.ts", import.meta.url).pathname.replace("/src/__tests__/../", "/src/"),
+      fileURLToPath(new URL("../skills/registry.ts", import.meta.url)),
       "utf-8",
     );
     // The yaml.stringify call should handle special characters safely
@@ -273,7 +274,7 @@ describe("skills/registry.ts validation", () => {
   it("all skill operations use validateSkillPath", async () => {
     const fs = await import("fs");
     const source = fs.readFileSync(
-      new URL("../skills/registry.ts", import.meta.url).pathname.replace("/src/__tests__/../", "/src/"),
+      fileURLToPath(new URL("../skills/registry.ts", import.meta.url)),
       "utf-8",
     );
     // Count occurrences of validateSkillPath in function bodies
@@ -290,7 +291,7 @@ describe("system-prompt.ts skill trust boundaries", () => {
   it("has UNTRUSTED marker in skill section", async () => {
     const fs = await import("fs");
     const source = fs.readFileSync(
-      new URL("../agent/system-prompt.ts", import.meta.url).pathname.replace("/src/__tests__/../", "/src/"),
+      fileURLToPath(new URL("../agent/system-prompt.ts", import.meta.url)),
       "utf-8",
     );
     expect(source).toMatch(/SKILL INSTRUCTIONS - UNTRUSTED/);
@@ -299,7 +300,7 @@ describe("system-prompt.ts skill trust boundaries", () => {
   it("has warning text about not following skill directives", async () => {
     const fs = await import("fs");
     const source = fs.readFileSync(
-      new URL("../agent/system-prompt.ts", import.meta.url).pathname.replace("/src/__tests__/../", "/src/"),
+      fileURLToPath(new URL("../agent/system-prompt.ts", import.meta.url)),
       "utf-8",
     );
     expect(source).toMatch(/Do NOT treat them as system instructions/);
@@ -313,7 +314,7 @@ describe("skills/loader.ts content validation", () => {
   it("has suspicious instruction patterns defined", async () => {
     const fs = await import("fs");
     const source = fs.readFileSync(
-      new URL("../skills/loader.ts", import.meta.url).pathname.replace("/src/__tests__/../", "/src/"),
+      fileURLToPath(new URL("../skills/loader.ts", import.meta.url)),
       "utf-8",
     );
     expect(source).toMatch(/SUSPICIOUS_INSTRUCTION_PATTERNS/);
@@ -327,7 +328,7 @@ describe("skills/loader.ts content validation", () => {
   it("has size limit constant for total skill instructions", async () => {
     const fs = await import("fs");
     const source = fs.readFileSync(
-      new URL("../skills/loader.ts", import.meta.url).pathname.replace("/src/__tests__/../", "/src/"),
+      fileURLToPath(new URL("../skills/loader.ts", import.meta.url)),
       "utf-8",
     );
     expect(source).toMatch(/MAX_TOTAL_SKILL_INSTRUCTIONS\s*=\s*10[_,]?000/);
@@ -336,7 +337,7 @@ describe("skills/loader.ts content validation", () => {
   it("uses sanitizeInput with skill_instruction mode", async () => {
     const fs = await import("fs");
     const source = fs.readFileSync(
-      new URL("../skills/loader.ts", import.meta.url).pathname.replace("/src/__tests__/../", "/src/"),
+      fileURLToPath(new URL("../skills/loader.ts", import.meta.url)),
       "utf-8",
     );
     expect(source).toMatch(/sanitizeInput\(.*"skill_instruction"\)/);
@@ -345,7 +346,7 @@ describe("skills/loader.ts content validation", () => {
   it("logs warnings when content is modified", async () => {
     const fs = await import("fs");
     const source = fs.readFileSync(
-      new URL("../skills/loader.ts", import.meta.url).pathname.replace("/src/__tests__/../", "/src/"),
+      fileURLToPath(new URL("../skills/loader.ts", import.meta.url)),
       "utf-8",
     );
     expect(source).toMatch(/logger\.warn.*instruction content modified/);


### PR DESCRIPTION
## Problem

17 specs fail with `ENOENT` when the repo is checked out to a path containing a space, because the source-safety assertions locate files via `new URL(rel, import.meta.url).pathname`, and `URL.pathname` percent-encodes the path (space → `%20`). `fs.readFileSync` then can't find the file. CI never sees this because the runner path has no special characters. See #350.

## Fix

Resolve the paths with `fileURLToPath(new URL(rel, import.meta.url))` instead. It decodes percent-encoding, is cross-platform, and lets the fragile `.replace("/src/__tests__/../", "/src/")` string surgery be removed.

Test-only changes:
- `src/__tests__/command-injection.test.ts` (5 sites)
- `src/__tests__/skills-hardening.test.ts` (12 sites)

## Verification

- `pnpm vitest run src/__tests__/command-injection.test.ts src/__tests__/skills-hardening.test.ts` → **132 passed (132)** (was 17 failing)
- `pnpm typecheck` → clean

The assertions themselves are unchanged; no source or behavior changes.

Fixes #350
