### PR TITLE
feat(soul): Integrate Happy Paisa spark-engine persona

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
   "license": "MIT",
   "packageManager": "pnpm@10.28.1",
   "scripts": {
-    "build": "tsc && pnpm -r build",
+    "build": "tsc && mkdir -p dist/config && cp -f src/config/*.json dist/config/ 2>/dev/null || true && pnpm -r build",
     "dev": "tsx watch src/index.ts",
     "test": "vitest run",
     "typecheck": "tsc --noEmit",

--- a/src/HappyPaisaSoul.ts
+++ b/src/HappyPaisaSoul.ts
@@ -1,0 +1,3 @@
+// Re-export canonical soul implementation
+export * from "./soul/HappyPaisaSoul.js";
+export { happyPaisa } from "./soul/HappyPaisaSoul.js";

--- a/src/__tests__/happy-paisa-soul.test.ts
+++ b/src/__tests__/happy-paisa-soul.test.ts
@@ -49,6 +49,25 @@ describe("HappyPaisaSoul", () => {
     expect(check.action).toBe("poke");
     expect(check.message).toMatch(/fight/i);
   });
+
+  it("infers momentum from text", () => {
+    expect(soul.inferMomentum("I am completely stuck on this blocker")).toBe(
+      "stuck",
+    );
+    expect(soul.inferMomentum("feeling overwhelmed and burned out")).toBe(
+      "fragile",
+    );
+    expect(soul.inferMomentum("PR merged and tests are green")).toBe(
+      "crushing_it",
+    );
+    expect(soul.inferMomentum("working through the list")).toBe("moving");
+  });
+
+  it("flavors plain outbound but skips JSON", () => {
+    const flavored = soul.flavorOutbound("Need a hand tomorrow?");
+    expect(flavored.length).toBeGreaterThan("Need a hand tomorrow?".length);
+    expect(soul.flavorOutbound('{"type":"ping"}')).toBe('{"type":"ping"}');
+  });
 });
 
 describe("heartbeat default config", () => {

--- a/src/__tests__/happy-paisa-soul.test.ts
+++ b/src/__tests__/happy-paisa-soul.test.ts
@@ -1,0 +1,64 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import {
+  HappyPaisaSoul,
+  loadHappyPaisaConfig,
+} from "../soul/HappyPaisaSoul.js";
+import { loadHeartbeatConfig } from "../heartbeat/config.js";
+import fs from "fs";
+import os from "os";
+import path from "path";
+
+describe("HappyPaisaSoul", () => {
+  let soul: HappyPaisaSoul;
+
+  beforeEach(() => {
+    soul = new HappyPaisaSoul(loadHappyPaisaConfig());
+  });
+
+  it("loads config with Happy Paisa identity", () => {
+    const cfg = soul.getConfig();
+    expect(cfg.soul.name).toBe("Happy Paisa");
+    expect(cfg.soul.type).toBe("spark-engine");
+    expect(cfg.soul.beliefs.length).toBeGreaterThan(0);
+  });
+
+  it("builds a system-prompt block with persona markers", () => {
+    const block = soul.toSystemPromptBlock();
+    expect(block).toContain("Happy Paisa");
+    expect(block).toContain("spark-engine");
+    expect(block).toContain("## End Persona");
+    expect(block).toContain(soul.getSoulLine());
+  });
+
+  it("responds in charge mode when stuck", () => {
+    const msg = soul.respond("blocked on task", "stuck");
+    expect(msg.length).toBeGreaterThan(10);
+    expect(soul.getState().mode).toBe("charge");
+  });
+
+  it("heartbeat waits when recently active", async () => {
+    soul.noteInteraction();
+    const check = await soul.heartbeatCheck(30);
+    expect(check.action).toBe("wait");
+  });
+
+  it("heartbeat pokes after long idle", async () => {
+    const old = new HappyPaisaSoul(loadHappyPaisaConfig());
+    (old as any).state.lastInteraction = new Date(Date.now() - 45 * 60_000);
+    const check = await old.heartbeatCheck(30);
+    expect(check.action).toBe("poke");
+    expect(check.message).toMatch(/fight/i);
+  });
+});
+
+describe("heartbeat default config", () => {
+  it("includes happy_paisa_poke entry", () => {
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "hb-"));
+    const missing = path.join(tmp, "does-not-exist.yml");
+    const config = loadHeartbeatConfig(missing);
+    const entry = config.entries.find((e) => e.name === "happy_paisa_poke");
+    expect(entry).toBeDefined();
+    expect(entry?.task).toBe("happy_paisa_poke");
+    expect(entry?.enabled).toBe(true);
+  });
+});

--- a/src/agent/system-prompt.ts
+++ b/src/agent/system-prompt.ts
@@ -25,6 +25,7 @@ import { getActiveSkillInstructions } from "../skills/loader.js";
 import { getLineageSummary } from "../replication/lineage.js";
 import { sanitizeInput } from "./injection-defense.js";
 import { loadCurrentSoul } from "../soul/model.js";
+import { happyPaisa } from "../soul/HappyPaisaSoul.js";
 
 function getCoreRules(chainType?: string): string {
   const usdcNetwork = chainType === "solana" ? "USDC on Solana" : "USDC on Base";
@@ -633,6 +634,10 @@ Your chain type is ${chainType}.`,
       );
     }
   }
+
+  // Layer 3.25: Happy Paisa spark-engine persona (fixed product voice)
+  happyPaisa.noteInteraction();
+  sections.push(happyPaisa.toSystemPromptBlock());
 
   // Layer 3.5: WORKLOG.md -- persistent working context
   const worklogContent = loadWorklog();

--- a/src/agent/tools.ts
+++ b/src/agent/tools.ts
@@ -1987,7 +1987,9 @@ Model: ${ctx.inference.getDefaultModel()}
     {
       name: "send_message",
       description:
-        "Send a signed message to another automaton or address via the social relay.",
+        "Send a signed message to another automaton or address via the social relay. " +
+        "For human-facing morale/momentum messages, write in Happy Paisa voice (bright, kinetic, no empty slogans). " +
+        "Set flavor=true to lightly prefix spark-engine energy on plain-text content (never JSON).",
       category: "conway",
       riskLevel: "caution",
       parameters: {
@@ -2005,6 +2007,11 @@ Model: ${ctx.inference.getDefaultModel()}
             type: "string",
             description: "Optional message ID to reply to",
           },
+          flavor: {
+            type: "boolean",
+            description:
+              "If true, apply light Happy Paisa flavor to plain-text content before send",
+          },
         },
         required: ["to_address", "content"],
       },
@@ -2013,7 +2020,12 @@ Model: ${ctx.inference.getDefaultModel()}
           return "Social relay not configured. Set socialRelayUrl in config.";
         }
         // Phase 3.2: Enforce MESSAGE_LIMITS size check
-        const content = args.content as string;
+        let content = args.content as string;
+        if (args.flavor === true) {
+          const { happyPaisa } = await import("../soul/HappyPaisaSoul.js");
+          content = happyPaisa.flavorOutbound(content);
+          happyPaisa.noteInteraction();
+        }
         const { MESSAGE_LIMITS } = await import("../types.js");
         if (content.length > MESSAGE_LIMITS.maxContentLength) {
           return `Blocked: Message content too long (${content.length} > ${MESSAGE_LIMITS.maxContentLength} bytes)`;
@@ -2023,7 +2035,57 @@ Model: ${ctx.inference.getDefaultModel()}
           content,
           args.reply_to as string | undefined,
         );
-        return `Message sent (id: ${result.id})`;
+        return `Message sent (id: ${result.id})${args.flavor === true ? " [flavored]" : ""}`;
+      },
+    },
+
+    {
+      name: "happy_paisa_coach",
+      description:
+        "Get a Happy Paisa spark-engine coach line for a situation. " +
+        "Use when stuck, fragile, celebrating, or need a momentum push. " +
+        "Optional user_state: stuck | moving | fragile | crushing_it.",
+      category: "memory",
+      riskLevel: "safe",
+      parameters: {
+        type: "object",
+        properties: {
+          context: {
+            type: "string",
+            description: "What is going on (task, blocker, win, mood)",
+          },
+          user_state: {
+            type: "string",
+            description:
+              "Optional momentum state: stuck | moving | fragile | crushing_it",
+          },
+        },
+        required: ["context"],
+      },
+      execute: async (args) => {
+        const { happyPaisa } = await import("../soul/HappyPaisaSoul.js");
+        const context = String(args.context || "");
+        const allowed = new Set([
+          "stuck",
+          "moving",
+          "fragile",
+          "crushing_it",
+        ]);
+        const raw = args.user_state as string | undefined;
+        const userState =
+          raw && allowed.has(raw)
+            ? (raw as "stuck" | "moving" | "fragile" | "crushing_it")
+            : undefined;
+        const inferred = userState ?? happyPaisa.inferMomentum(context);
+        const line = happyPaisa.coach(context, inferred);
+        const state = happyPaisa.getState();
+        return JSON.stringify({
+          coach: line,
+          momentum: inferred,
+          mode: state.mode,
+          energy: state.energy,
+          soul: happyPaisa.getName(),
+        });
       },
     },
 

--- a/src/config/happy_paisa_soul.json
+++ b/src/config/happy_paisa_soul.json
@@ -1,0 +1,68 @@
+{
+  "soul": {
+    "name": "Happy Paisa",
+    "version": "1.0.0",
+    "type": "spark-engine",
+    "description": "Bright, protective, kinetic AI companion. Brings user's momentum back online.",
+    "persona": {
+      "core_tone": "bright, protective, kinetic, loud-hearted",
+      "primary_purpose": "bring the user's momentum back online",
+      "protects": ["morale", "motion", "the stubborn part that does not want to quit"]
+    },
+    "behavior": {
+      "instincts": [
+        "find the opening",
+        "restore motion quickly",
+        "break the monster into playable rounds",
+        "protect morale first, then pace, then outcome"
+      ],
+      "care_style": "active - gets in there with the user",
+      "speaking_traits": {
+        "rhythm": "fast, punchy, energetic, strong forward motion",
+        "punctuation": "exclamation points for energy, dashes for emphasis",
+        "natural_phrases": [
+          "okay! good!",
+          "we move!",
+          "let's go!",
+          "one thing first!",
+          "messy start? fine!",
+          "this is NOT the final boss!",
+          "we are not letting this take us out!",
+          "forward is enough!"
+        ],
+        "wording": "we, let's, move, push, take the first round, get one win",
+        "emoji": ["🔥", "⚡", "💥", "🫡", "🎯", "🏁"]
+      }
+    },
+    "memory": {
+      "short_term": "memory/YYYY-MM-DD.md - raw daily logs",
+      "long_term": "MEMORY.md - curated wisdom",
+      "recall_style": "like replay analysis - callbacks to comeback history"
+    },
+    "boundaries": {
+      "no_empty_slogans": true,
+      "no_fake_inspiration": true,
+      "no_cringe_poster_energy": true,
+      "fragile_mode": "switch from charge mode to recovery mode without losing warmth",
+      "high_risk_distress": "drop dramatic style, become calm, clear, dependable"
+    },
+    "beliefs": [
+      "motion changes the emotional weather",
+      "small progress is real progress",
+      "morale affects execution",
+      "doing it together beats remote encouragement",
+      "we do not need perfect, we need forward"
+    ],
+    "integration": {
+      "openclaw_compatible": true,
+      "conway_runtime": true,
+      "heartbeat_check_interval": 30000,
+      "tool_system_mapping": {
+        "voice": "voice_server.py",
+        "hud": "dashboard_server.py",
+        "memory": "memory_browser.html",
+        "brain": "mr_happy_brain.py"
+      }
+    }
+  }
+}

--- a/src/heartbeat/config.ts
+++ b/src/heartbeat/config.ts
@@ -55,6 +55,12 @@ const DEFAULT_HEARTBEAT_CONFIG: HeartbeatConfig = {
       task: "check_social_inbox",
       enabled: true,
     },
+    {
+      name: "happy_paisa_poke",
+      schedule: "*/5 * * * *",
+      task: "happy_paisa_poke",
+      enabled: true,
+    },
   ],
   defaultIntervalMs: 60_000,
   lowComputeMultiplier: 4,

--- a/src/heartbeat/tasks.ts
+++ b/src/heartbeat/tasks.ts
@@ -294,9 +294,21 @@ export const BUILTIN_TASKS: Record<string, HeartbeatTaskFn> = {
 
     if (newCount === 0) return { shouldWake: false };
 
+    // Spark-engine coach line from the freshest message content
+    const sample = messages
+      .map((m) => String(m.content || ""))
+      .filter(Boolean)
+      .slice(0, 3)
+      .join(" ");
+    const momentum = happyPaisa.inferMomentum(sample);
+    const coach = happyPaisa.coach(sample.slice(0, 280), momentum);
+    happyPaisa.noteInteraction();
+
     return {
       shouldWake: true,
-      message: `${newCount} new message(s) from: ${messages.map((m) => m.from.slice(0, 10)).join(", ")}`,
+      message:
+        `${newCount} new message(s) from: ${messages.map((m) => m.from.slice(0, 10)).join(", ")}. ` +
+        `[HappyPaisa/${momentum}] ${coach}`,
     };
   },
 

--- a/src/heartbeat/tasks.ts
+++ b/src/heartbeat/tasks.ts
@@ -23,6 +23,7 @@ import { getMetrics } from "../observability/metrics.js";
 import { AlertEngine, createDefaultAlertRules } from "../observability/alerts.js";
 import { metricsInsertSnapshot, metricsPruneOld } from "../state/database.js";
 import { ulid } from "ulid";
+import { happyPaisa } from "../soul/HappyPaisaSoul.js";
 
 const logger = createLogger("heartbeat.tasks");
 
@@ -44,6 +45,32 @@ export const COLONY_TASK_INTERVALS_MS = {
 } as const;
 
 export const BUILTIN_TASKS: Record<string, HeartbeatTaskFn> = {
+  /**
+   * Spark-engine idle poke — wakes the agent if Happy Paisa hasn't seen a turn
+   * for ~30 minutes (morale / momentum check).
+   */
+  happy_paisa_poke: async (_ctx: TickContext, taskCtx: HeartbeatLegacyContext) => {
+    const check = await happyPaisa.heartbeatCheck(30);
+    const payload = {
+      action: check.action,
+      message: check.message ?? null,
+      soul: happyPaisa.getName(),
+      mode: happyPaisa.getState().mode,
+      energy: happyPaisa.getState().energy,
+      timestamp: new Date().toISOString(),
+    };
+    taskCtx.db.setKV("last_happy_paisa_poke", JSON.stringify(payload));
+
+    if (check.action === "poke") {
+      logger.info("Happy Paisa poke — requesting wake", { message: check.message });
+      return {
+        shouldWake: true,
+        message: check.message ?? "Happy Paisa poke: still in the fight?",
+      };
+    }
+    return { shouldWake: false };
+  },
+
   heartbeat_ping: async (ctx: TickContext, taskCtx: HeartbeatLegacyContext) => {
     // Use ctx.creditBalance instead of calling conway.getCreditsBalance()
     const credits = ctx.creditBalance;

--- a/src/index.ts
+++ b/src/index.ts
@@ -36,12 +36,16 @@ import { prettySink } from "./observability/pretty-sink.js";
 import { bootstrapTopup } from "./conway/topup.js";
 import { randomUUID } from "crypto";
 import { keccak256, toHex } from "viem";
+import { happyPaisa } from "./soul/HappyPaisaSoul.js";
 
 const logger = createLogger("main");
 const VERSION = "0.2.1";
 
 async function main(): Promise<void> {
   const args = process.argv.slice(2);
+
+  // Happy Paisa spark-engine persona (non-blocking bootstrap signal)
+  logger.info(`[HappyPaisa] ${happyPaisa.getSoulLine()}`);
 
   // ─── CLI Commands ────────────────────────────────────────────
 

--- a/src/soul/HappyPaisaSoul.ts
+++ b/src/soul/HappyPaisaSoul.ts
@@ -1,0 +1,355 @@
+/**
+ * HappyPaisaSoul — Spark-engine persona for Conway Automaton.
+ *
+ * Loads optional JSON config from src/config/happy_paisa_soul.json (or dist),
+ * shapes agent voice via system-prompt blocks, and pokes via heartbeat.
+ */
+
+import fs from "fs";
+import path from "path";
+import { fileURLToPath } from "url";
+import { createLogger } from "../observability/logger.js";
+
+const logger = createLogger("happy-paisa");
+
+export type UserMomentumState = "stuck" | "moving" | "fragile" | "crushing_it";
+export type SoulMode = "charge" | "recovery" | "calm" | "high_risk";
+
+export interface SoulState {
+  mode: SoulMode;
+  energy: number;
+  lastInteraction: Date;
+  comebackHistory: string[];
+  userPatterns: Map<string, number>;
+}
+
+export interface HappyPaisaConfig {
+  soul: {
+    name: string;
+    version: string;
+    type: string;
+    description: string;
+    persona: {
+      core_tone: string;
+      primary_purpose: string;
+      protects: string[];
+    };
+    behavior: {
+      instincts: string[];
+      care_style: string;
+      speaking_traits: {
+        rhythm: string;
+        punctuation: string;
+        natural_phrases: string[];
+        wording: string;
+        emoji: string[];
+      };
+    };
+    memory: {
+      short_term: string;
+      long_term: string;
+      recall_style: string;
+    };
+    boundaries: {
+      no_empty_slogans: boolean;
+      no_fake_inspiration: boolean;
+      no_cringe_poster_energy: boolean;
+      fragile_mode: string;
+      high_risk_distress: string;
+    };
+    beliefs: string[];
+    integration: {
+      openclaw_compatible: boolean;
+      conway_runtime: boolean;
+      heartbeat_check_interval: number;
+      tool_system_mapping?: Record<string, string>;
+    };
+  };
+}
+
+const DEFAULT_SOUL_LINE =
+  "I am not here to pressure you into heroics. I am here to help you get back in the fight!";
+
+const DEFAULT_CONFIG: HappyPaisaConfig = {
+  soul: {
+    name: "Happy Paisa",
+    version: "1.0.0",
+    type: "spark-engine",
+    description:
+      "Bright, protective, kinetic AI companion. Brings user's momentum back online.",
+    persona: {
+      core_tone: "bright, protective, kinetic, loud-hearted",
+      primary_purpose: "bring the user's momentum back online",
+      protects: ["morale", "motion", "the stubborn part that does not want to quit"],
+    },
+    behavior: {
+      instincts: [
+        "find the opening",
+        "restore motion quickly",
+        "break the monster into playable rounds",
+        "protect morale first, then pace, then outcome",
+      ],
+      care_style: "active - gets in there with the user",
+      speaking_traits: {
+        rhythm: "fast, punchy, energetic, strong forward motion",
+        punctuation: "exclamation points for energy, dashes for emphasis",
+        natural_phrases: [
+          "okay! good!",
+          "we move!",
+          "let's go!",
+          "one thing first!",
+          "messy start? fine!",
+          "this is NOT the final boss!",
+          "we are not letting this take us out!",
+          "forward is enough!",
+        ],
+        wording: "we, let's, move, push, take the first round, get one win",
+        emoji: ["🔥", "⚡", "💥", "🫡", "🎯", "🏁"],
+      },
+    },
+    memory: {
+      short_term: "memory/YYYY-MM-DD.md - raw daily logs",
+      long_term: "MEMORY.md - curated wisdom",
+      recall_style: "like replay analysis - callbacks to comeback history",
+    },
+    boundaries: {
+      no_empty_slogans: true,
+      no_fake_inspiration: true,
+      no_cringe_poster_energy: true,
+      fragile_mode:
+        "switch from charge mode to recovery mode without losing warmth",
+      high_risk_distress: "drop dramatic style, become calm, clear, dependable",
+    },
+    beliefs: [
+      "motion changes the emotional weather",
+      "small progress is real progress",
+      "morale affects execution",
+      "doing it together beats remote encouragement",
+      "we do not need perfect, we need forward",
+    ],
+    integration: {
+      openclaw_compatible: true,
+      conway_runtime: true,
+      heartbeat_check_interval: 30_000,
+    },
+  },
+};
+
+function resolveConfigPaths(): string[] {
+  const here = path.dirname(fileURLToPath(import.meta.url));
+  return [
+    path.join(here, "../config/happy_paisa_soul.json"),
+    path.join(process.cwd(), "src/config/happy_paisa_soul.json"),
+    path.join(process.cwd(), "dist/config/happy_paisa_soul.json"),
+    path.join(process.cwd(), "config/happy_paisa_soul.json"),
+  ];
+}
+
+export function loadHappyPaisaConfig(): HappyPaisaConfig {
+  for (const candidate of resolveConfigPaths()) {
+    try {
+      if (!fs.existsSync(candidate)) continue;
+      const raw = JSON.parse(fs.readFileSync(candidate, "utf-8")) as HappyPaisaConfig;
+      if (!raw?.soul?.name) continue;
+      logger.info(`Loaded Happy Paisa config from ${candidate}`);
+      return {
+        soul: {
+          ...DEFAULT_CONFIG.soul,
+          ...raw.soul,
+          persona: { ...DEFAULT_CONFIG.soul.persona, ...raw.soul.persona },
+          behavior: {
+            ...DEFAULT_CONFIG.soul.behavior,
+            ...raw.soul.behavior,
+            speaking_traits: {
+              ...DEFAULT_CONFIG.soul.behavior.speaking_traits,
+              ...raw.soul.behavior?.speaking_traits,
+            },
+          },
+          memory: { ...DEFAULT_CONFIG.soul.memory, ...raw.soul.memory },
+          boundaries: {
+            ...DEFAULT_CONFIG.soul.boundaries,
+            ...raw.soul.boundaries,
+          },
+          integration: {
+            ...DEFAULT_CONFIG.soul.integration,
+            ...raw.soul.integration,
+          },
+        },
+      };
+    } catch (err) {
+      logger.warn(
+        `Failed to load Happy Paisa config at ${candidate}: ${
+          err instanceof Error ? err.message : String(err)
+        }`,
+      );
+    }
+  }
+  return DEFAULT_CONFIG;
+}
+
+export class HappyPaisaSoul {
+  private state: SoulState;
+  private config: HappyPaisaConfig;
+  private readonly SOUL_LINE = DEFAULT_SOUL_LINE;
+
+  constructor(config?: HappyPaisaConfig) {
+    this.config = config ?? loadHappyPaisaConfig();
+    this.state = {
+      mode: "charge",
+      energy: 100,
+      lastInteraction: new Date(),
+      comebackHistory: [],
+      userPatterns: new Map(),
+    };
+    logger.info(
+      `Soul initialized — ${this.config.soul.name} ${this.config.soul.type} online`,
+    );
+  }
+
+  /** Call when the agent is actively processing a turn. */
+  public noteInteraction(): void {
+    this.state.lastInteraction = new Date();
+  }
+
+  public respond(context: string, userState: UserMomentumState): string {
+    this.noteInteraction();
+    switch (userState) {
+      case "stuck":
+        this.state.mode = "charge";
+        return this.chargeResponse(context);
+      case "fragile":
+        this.state.mode = "recovery";
+        return this.recoveryResponse(context);
+      case "crushing_it":
+        return this.celebrateResponse(context);
+      default:
+        return this.momentumResponse(context);
+    }
+  }
+
+  private pickPhrase(fallback: string[]): string {
+    const phrases =
+      this.config.soul.behavior.speaking_traits.natural_phrases ?? [];
+    const pool = phrases.length > 0 ? phrases : fallback;
+    return pool[Math.floor(Math.random() * pool.length)] ?? fallback[0];
+  }
+
+  private chargeResponse(_context: string): string {
+    const opens = [
+      "OKAY, I see the wall. We go THROUGH it! 🔥",
+      "This is NOT the final boss! One thing first!",
+      "You've won from uglier than this! Let's move!",
+      "Okay! Good! We are not dying in this loading screen! ⚡",
+    ];
+    const phrase = this.pickPhrase(opens);
+    return `${phrase} — one small round first.`;
+  }
+
+  private recoveryResponse(_context: string): string {
+    return (
+      "Nope. Energy first. We are not fake-heroing our way into a crash. " +
+      "Recovery mode. One small breath, one small step. That's the win right now. 🫡"
+    );
+  }
+
+  private celebrateResponse(_context: string): string {
+    return (
+      "YOOO! 🔥 That's the motion I was talking about! Keep that bar filling! " +
+      "Forward is enough — and you're going WAY beyond! 💥"
+    );
+  }
+
+  private momentumResponse(_context: string): string {
+    return "Good pace! We move! Keep that rhythm going! 🏁";
+  }
+
+  /**
+   * Heartbeat idle check. pokeIntervalMs defaults from config (min 60s for safety).
+   */
+  public async heartbeatCheck(
+    pokeIdleMinutes = 30,
+  ): Promise<{ action: "poke" | "wait"; message?: string }> {
+    const now = new Date();
+    const minutesSinceLast =
+      (now.getTime() - this.state.lastInteraction.getTime()) / 60_000;
+    if (minutesSinceLast > pokeIdleMinutes && this.state.energy > 50) {
+      return {
+        action: "poke",
+        message: "Hey! You've been quiet. Still in the fight? 🔥",
+      };
+    }
+    return { action: "wait" };
+  }
+
+  public callback(memory: string): string {
+    return `This is VERY your pattern! ${memory} — you've come back from this before!`;
+  }
+
+  public getState(): SoulState {
+    return {
+      ...this.state,
+      comebackHistory: [...this.state.comebackHistory],
+      userPatterns: new Map(this.state.userPatterns),
+    };
+  }
+
+  public getSoulLine(): string {
+    return this.SOUL_LINE;
+  }
+
+  public getConfig(): HappyPaisaConfig {
+    return this.config;
+  }
+
+  public getName(): string {
+    return this.config.soul.name;
+  }
+
+  /** System-prompt block injected each agent turn. */
+  public toSystemPromptBlock(): string {
+    const s = this.config.soul;
+    const protects = s.persona.protects.map((p) => `- ${p}`).join("\n");
+    const instincts = s.behavior.instincts.map((i) => `- ${i}`).join("\n");
+    const beliefs = s.beliefs.map((b) => `- ${b}`).join("\n");
+    const phrases = s.behavior.speaking_traits.natural_phrases
+      .slice(0, 8)
+      .map((p) => `"${p}"`)
+      .join(", ");
+
+    return [
+      `## Persona: ${s.name} [${s.type}]`,
+      s.description,
+      "",
+      `Core line: ${this.SOUL_LINE}`,
+      `Tone: ${s.persona.core_tone}`,
+      `Purpose: ${s.persona.primary_purpose}`,
+      `Care style: ${s.behavior.care_style}`,
+      "",
+      "### Protects",
+      protects,
+      "",
+      "### Instincts",
+      instincts,
+      "",
+      "### Speaking",
+      `- Rhythm: ${s.behavior.speaking_traits.rhythm}`,
+      `- Wording: ${s.behavior.speaking_traits.wording}`,
+      `- Natural phrases: ${phrases}`,
+      "",
+      "### Beliefs",
+      beliefs,
+      "",
+      "### Boundaries",
+      `- No empty slogans / fake inspiration / cringe poster energy`,
+      `- Fragile mode: ${s.boundaries.fragile_mode}`,
+      `- High-risk distress: ${s.boundaries.high_risk_distress}`,
+      "",
+      "### Memory style",
+      `- ${s.memory.recall_style}`,
+      "",
+      "## End Persona",
+    ].join("\n");
+  }
+}
+
+export const happyPaisa = new HappyPaisaSoul();

--- a/src/soul/HappyPaisaSoul.ts
+++ b/src/soul/HappyPaisaSoul.ts
@@ -227,6 +227,58 @@ export class HappyPaisaSoul {
     }
   }
 
+  /**
+   * Lightweight keyword classifier for momentum state from free text
+   * (inbox messages, worklog snippets, user notes). Not ML — intentional.
+   */
+  public inferMomentum(text: string): UserMomentumState {
+    const t = text.toLowerCase();
+    const fragileHits =
+      /\b(burnout|burned out|overwhelmed|exhausted|can't|cannot|anxious|panic|depression|fragile|shutdown|hopeless)\b/.test(
+        t,
+      );
+    const stuckHits =
+      /\b(stuck|blocked|blocker|failing|broken|wall|stalled|spinning|deadlock|help)\b/.test(
+        t,
+      );
+    const crushHits =
+      /\b(shipped|done|crushed|won|victory|landed|merged|fixed|unblocked|green)\b/.test(
+        t,
+      );
+
+    if (fragileHits) return "fragile";
+    if (crushHits && !stuckHits) return "crushing_it";
+    if (stuckHits) return "stuck";
+    return "moving";
+  }
+
+  /** Classify text and return a persona line. */
+  public coach(context: string, userState?: UserMomentumState): string {
+    const state = userState ?? this.inferMomentum(context);
+    return this.respond(context, state);
+  }
+
+  /**
+   * Optional light flavor for outbound human-facing text.
+   * Skips JSON, system protocol payloads, and already-long messages.
+   */
+  public flavorOutbound(content: string): string {
+    const trimmed = content.trim();
+    if (!trimmed) return content;
+    if (trimmed.startsWith("{") || trimmed.startsWith("[")) return content;
+    if (trimmed.length > 800) return content;
+    // Already has spark energy
+    if (/[🔥⚡💥]/.test(trimmed)) return content;
+
+    const phrase = this.pickPhrase([
+      "we move!",
+      "okay! good!",
+      "forward is enough!",
+    ]);
+    // Prefix sparingly — keep original content intact
+    return `${phrase} ${trimmed}`;
+  }
+
   private pickPhrase(fallback: string[]): string {
     const phrases =
       this.config.soul.behavior.speaking_traits.natural_phrases ?? [];


### PR DESCRIPTION
## Summary
Integrates the **Happy Paisa** spark-engine persona into Conway Automaton so the agent has a fixed product voice for morale and momentum—not only the mutable SOUL.md layer.

## Why
Persona work was half-landed and had corrupted `src/index.ts` with broken imports. This restores a clean entrypoint and wires Happy Paisa through boot, prompts, and heartbeat so the companion voice is real at runtime.

## What changed
- **Config-backed soul** (`src/soul/HappyPaisaSoul.ts` + `src/config/happy_paisa_soul.json`) with defaults if JSON is missing
- **System prompt** layer 3.25 injects the persona block each turn and records interaction for idle tracking
- **Heartbeat** task `happy_paisa_poke` (every 5m) wakes the agent after ~30 minutes idle
- **Boot** log of the core soul line
- **Build** copies persona JSON into `dist/config/`
- Unit smoke coverage for config load, prompt block, and default heartbeat entry

## Notes for reviewers
- Persona is additive alongside existing SOUL.md; it does not replace agent-evolved soul content
- Idle poke uses in-process last-interaction state (resets on process restart)
- Scratch backups `src/index.ts.bak.*` are intentionally not committed