### PR TITLE
Fix typo in README: perfomance -> performance

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ For automated sandbox provisioning:
 curl -fsSL https://conway.tech/automaton.sh | sh
 ```
 
-Note: Conway Cloud, Domains, and Inference has seen immense demand. We are working on scaling & perfomance.
+Note: Conway Cloud, Domains, and Inference has seen immense demand. We are working on scaling & performance.
 
 ## How It Works
 


### PR DESCRIPTION
## Summary
- Fixes a small typo in the README ("perfomance" -> "performance") in the Quick Start section note about Conway Cloud scaling.

## Test plan
- Docs-only change, no tests needed.