### PR TITLE
fix(ci): make the security test filter actually apply

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,7 +28,7 @@ jobs:
         timeout-minutes: 10
         run: |
           set +e
-          timeout 180 pnpm test -- --grep "security|injection|policy|financial"
+          timeout 180 pnpm test --testNamePattern "security|injection|policy|financial"
           RC=$?
           set -e
           if [ $RC -eq 124 ]; then echo "::warning::vitest process hung after tests, killed by timeout"; exit 0; fi

--- a/package.json
+++ b/package.json
@@ -43,8 +43,8 @@
     "test": "vitest run",
     "typecheck": "tsc --noEmit",
     "test:coverage": "vitest run --coverage",
-    "test:security": "vitest run --grep 'security|injection|policy'",
-    "test:financial": "vitest run --grep 'financial|spend|treasury'",
+    "test:security": "vitest run --testNamePattern 'security|injection|policy'",
+    "test:financial": "vitest run --testNamePattern 'financial|spend|treasury'",
     "test:ci": "vitest run --reporter=verbose",
     "clean": "rm -rf dist && pnpm -r clean"
   },


### PR DESCRIPTION
## Problem

The `Run security tests` step in `.github/workflows/ci.yml` has never filtered anything. Two defects stack:

1. **`--grep` is not a vitest option.** That is the mocha/jest spelling; vitest uses `--testNamePattern`. The flag was silently ignored.
2. **`pnpm test -- <args>` does not forward arguments** under pnpm 10, so even the correct flag never reached vitest.

Measured on `main`, same pattern, only the invocation differs:

| command | tests run |
|---|---|
| `pnpm test -- --testNamePattern 'financial\|spend\|treasury'` | 1643 |
| `pnpm test --testNamePattern 'financial\|spend\|treasury'` | 37 |

## Consequence

The step ran the **entire** suite, exceeded its `timeout 180`, and was killed. The exit-code branch below then reported success:

```sh
if [ $RC -eq 124 ]; then echo "::warning::vitest process hung after tests, killed by timeout"; exit 0; fi
```

So the step has never gated on anything — **a failing security test would have been reported green**. The `::warning::` fired on every run and read as benign, since the message attributes the kill to a hang after completion rather than to the suite never fitting in the budget.

## Fix

Drop the `--`, and use `--testNamePattern`. Same change applied to the `test:security` and `test:financial` scripts in `package.json`, which carry the identical `--grep` mistake.

## Verification

On `ubuntu-latest`, Node 20 and 22:

| | before | after |
|---|---|---|
| masking warnings | 2 | 0 |
| security step | whole suite, killed at 180s | 155 passed, 1488 skipped |
| step duration | 180s (timeout) | 19-23s |
| total CI duration | 420s | 240s |

This change is self-contained: it does not depend on any other fix, and the filtered selection completes in ~7s on a clean checkout of `main`.

## Note, not addressed here

The `package.json` scripts keep single quotes around the pattern. The Windows shell does not honour them, so the `|` is parsed as a command separator and those scripts fail locally on Windows. Pre-existing and harmless on the Linux CI, so it is left out to keep this diff minimal.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012WAheHPLGuvZFKLHY4YW3T