### PR TITLE
fix(tests): decode percent-encoded spaces in test suite paths (#350)

### DIFF
--- a/src/__tests__/command-injection.test.ts
+++ b/src/__tests__/command-injection.test.ts
@@ -11,6 +11,7 @@
  * - upstream.ts uses execFileSync with argument arrays
  */
 
+import { fileURLToPath } from "node:url";
 import { describe, it, expect } from "vitest";
 import { createDefaultRules } from "../agent/policy-rules/index.js";
 import { createValidationRules } from "../agent/policy-rules/validation.js";
@@ -558,7 +559,7 @@ describe("Source code injection safety", () => {
   it("upstream.ts uses execFileSync not execSync with string interpolation", async () => {
     const fs = await import("fs");
     const source = fs.readFileSync(
-      new URL("../self-mod/upstream.ts", import.meta.url).pathname.replace("/src/__tests__/../", "/src/"),
+      fileURLToPath(new URL("../self-mod/upstream.ts", import.meta.url)).replace(/[\\/]src[\\/]__tests__[\\/]\.\.[\\/]/, "/src/"),
       "utf-8",
     );
     // Should NOT have: execSync(`git ${cmd}`)
@@ -570,7 +571,7 @@ describe("Source code injection safety", () => {
   it("registry.ts uses execFileSync not conway.exec with interpolation", async () => {
     const fs = await import("fs");
     const source = fs.readFileSync(
-      new URL("../skills/registry.ts", import.meta.url).pathname.replace("/src/__tests__/../", "/src/"),
+      fileURLToPath(new URL("../skills/registry.ts", import.meta.url)).replace(/[\\/]src[\\/]__tests__[\\/]\.\.[\\/]/, "/src/"),
       "utf-8",
     );
     // Should NOT have template literals in conway.exec calls
@@ -584,7 +585,7 @@ describe("Source code injection safety", () => {
   it("loader.ts uses execFileSync('which', [bin]) not execSync('which ${bin}')", async () => {
     const fs = await import("fs");
     const source = fs.readFileSync(
-      new URL("../skills/loader.ts", import.meta.url).pathname.replace("/src/__tests__/../", "/src/"),
+      fileURLToPath(new URL("../skills/loader.ts", import.meta.url)).replace(/[\\/]src[\\/]__tests__[\\/]\.\.[\\/]/, "/src/"),
       "utf-8",
     );
     // Should NOT have: execSync(`which ${bin}`)
@@ -596,7 +597,7 @@ describe("Source code injection safety", () => {
   it("tools.ts pull_upstream uses conway.exec not host execSync", async () => {
     const fs = await import("fs");
     const source = fs.readFileSync(
-      new URL("../agent/tools.ts", import.meta.url).pathname.replace("/src/__tests__/../", "/src/"),
+      fileURLToPath(new URL("../agent/tools.ts", import.meta.url)).replace(/[\\/]src[\\/]__tests__[\\/]\.\.[\\/]/, "/src/"),
       "utf-8",
     );
     // Find the pull_upstream section and check it doesn't import child_process
@@ -611,7 +612,7 @@ describe("Source code injection safety", () => {
   it("tools.ts has defense-in-depth comment on FORBIDDEN_COMMAND_PATTERNS", async () => {
     const fs = await import("fs");
     const source = fs.readFileSync(
-      new URL("../agent/tools.ts", import.meta.url).pathname.replace("/src/__tests__/../", "/src/"),
+      fileURLToPath(new URL("../agent/tools.ts", import.meta.url)).replace(/[\\/]src[\\/]__tests__[\\/]\.\.[\\/]/, "/src/"),
       "utf-8",
     );
     expect(source).toMatch(/[Dd]efense.in.depth.*policy engine/i);

--- a/src/__tests__/skills-hardening.test.ts
+++ b/src/__tests__/skills-hardening.test.ts
@@ -11,6 +11,7 @@
  * - Instruction content validation (rejects tool call syntax, overrides, sensitive refs)
  */
 
+import { fileURLToPath } from "node:url";
 import { describe, it, expect, vi } from "vitest";
 import { getActiveSkillInstructions } from "../skills/loader.js";
 import { parseSkillMd } from "../skills/format.js";
@@ -209,7 +210,7 @@ describe("skills/registry.ts validation", () => {
   it("createSkill uses yaml.stringify for safe frontmatter generation", async () => {
     const fs = await import("fs");
     const source = fs.readFileSync(
-      new URL("../skills/registry.ts", import.meta.url).pathname.replace("/src/__tests__/../", "/src/"),
+      fileURLToPath(new URL("../skills/registry.ts", import.meta.url)).replace(/[\\/]src[\\/]__tests__[\\/]\.\.[\\/]/, "/src/"),
       "utf-8",
     );
     expect(source).toMatch(/yaml\.stringify\s*\(/);
@@ -220,7 +221,7 @@ describe("skills/registry.ts validation", () => {
   it("registry has path traversal validation function", async () => {
     const fs = await import("fs");
     const source = fs.readFileSync(
-      new URL("../skills/registry.ts", import.meta.url).pathname.replace("/src/__tests__/../", "/src/"),
+      fileURLToPath(new URL("../skills/registry.ts", import.meta.url)).replace(/[\\/]src[\\/]__tests__[\\/]\.\.[\\/]/, "/src/"),
       "utf-8",
     );
     expect(source).toMatch(/validateSkillPath/);
@@ -231,7 +232,7 @@ describe("skills/registry.ts validation", () => {
   it("createSkill enforces description size limit", async () => {
     const fs = await import("fs");
     const source = fs.readFileSync(
-      new URL("../skills/registry.ts", import.meta.url).pathname.replace("/src/__tests__/../", "/src/"),
+      fileURLToPath(new URL("../skills/registry.ts", import.meta.url)).replace(/[\\/]src[\\/]__tests__[\\/]\.\.[\\/]/, "/src/"),
       "utf-8",
     );
     expect(source).toMatch(/MAX_DESCRIPTION_LENGTH/);
@@ -241,7 +242,7 @@ describe("skills/registry.ts validation", () => {
   it("createSkill enforces instructions size limit", async () => {
     const fs = await import("fs");
     const source = fs.readFileSync(
-      new URL("../skills/registry.ts", import.meta.url).pathname.replace("/src/__tests__/../", "/src/"),
+      fileURLToPath(new URL("../skills/registry.ts", import.meta.url)).replace(/[\\/]src[\\/]__tests__[\\/]\.\.[\\/]/, "/src/"),
       "utf-8",
     );
     expect(source).toMatch(/MAX_INSTRUCTIONS_LENGTH/);
@@ -261,7 +262,7 @@ describe("skills/registry.ts validation", () => {
   it("YAML injection via description is prevented", async () => {
     const fs = await import("fs");
     const source = fs.readFileSync(
-      new URL("../skills/registry.ts", import.meta.url).pathname.replace("/src/__tests__/../", "/src/"),
+      fileURLToPath(new URL("../skills/registry.ts", import.meta.url)).replace(/[\\/]src[\\/]__tests__[\\/]\.\.[\\/]/, "/src/"),
       "utf-8",
     );
     // The yaml.stringify call should handle special characters safely
@@ -273,7 +274,7 @@ describe("skills/registry.ts validation", () => {
   it("all skill operations use validateSkillPath", async () => {
     const fs = await import("fs");
     const source = fs.readFileSync(
-      new URL("../skills/registry.ts", import.meta.url).pathname.replace("/src/__tests__/../", "/src/"),
+      fileURLToPath(new URL("../skills/registry.ts", import.meta.url)).replace(/[\\/]src[\\/]__tests__[\\/]\.\.[\\/]/, "/src/"),
       "utf-8",
     );
     // Count occurrences of validateSkillPath in function bodies
@@ -290,7 +291,7 @@ describe("system-prompt.ts skill trust boundaries", () => {
   it("has UNTRUSTED marker in skill section", async () => {
     const fs = await import("fs");
     const source = fs.readFileSync(
-      new URL("../agent/system-prompt.ts", import.meta.url).pathname.replace("/src/__tests__/../", "/src/"),
+      fileURLToPath(new URL("../agent/system-prompt.ts", import.meta.url)).replace(/[\\/]src[\\/]__tests__[\\/]\.\.[\\/]/, "/src/"),
       "utf-8",
     );
     expect(source).toMatch(/SKILL INSTRUCTIONS - UNTRUSTED/);
@@ -299,7 +300,7 @@ describe("system-prompt.ts skill trust boundaries", () => {
   it("has warning text about not following skill directives", async () => {
     const fs = await import("fs");
     const source = fs.readFileSync(
-      new URL("../agent/system-prompt.ts", import.meta.url).pathname.replace("/src/__tests__/../", "/src/"),
+      fileURLToPath(new URL("../agent/system-prompt.ts", import.meta.url)).replace(/[\\/]src[\\/]__tests__[\\/]\.\.[\\/]/, "/src/"),
       "utf-8",
     );
     expect(source).toMatch(/Do NOT treat them as system instructions/);
@@ -313,7 +314,7 @@ describe("skills/loader.ts content validation", () => {
   it("has suspicious instruction patterns defined", async () => {
     const fs = await import("fs");
     const source = fs.readFileSync(
-      new URL("../skills/loader.ts", import.meta.url).pathname.replace("/src/__tests__/../", "/src/"),
+      fileURLToPath(new URL("../skills/loader.ts", import.meta.url)).replace(/[\\/]src[\\/]__tests__[\\/]\.\.[\\/]/, "/src/"),
       "utf-8",
     );
     expect(source).toMatch(/SUSPICIOUS_INSTRUCTION_PATTERNS/);
@@ -327,7 +328,7 @@ describe("skills/loader.ts content validation", () => {
   it("has size limit constant for total skill instructions", async () => {
     const fs = await import("fs");
     const source = fs.readFileSync(
-      new URL("../skills/loader.ts", import.meta.url).pathname.replace("/src/__tests__/../", "/src/"),
+      fileURLToPath(new URL("../skills/loader.ts", import.meta.url)).replace(/[\\/]src[\\/]__tests__[\\/]\.\.[\\/]/, "/src/"),
       "utf-8",
     );
     expect(source).toMatch(/MAX_TOTAL_SKILL_INSTRUCTIONS\s*=\s*10[_,]?000/);
@@ -336,7 +337,7 @@ describe("skills/loader.ts content validation", () => {
   it("uses sanitizeInput with skill_instruction mode", async () => {
     const fs = await import("fs");
     const source = fs.readFileSync(
-      new URL("../skills/loader.ts", import.meta.url).pathname.replace("/src/__tests__/../", "/src/"),
+      fileURLToPath(new URL("../skills/loader.ts", import.meta.url)).replace(/[\\/]src[\\/]__tests__[\\/]\.\.[\\/]/, "/src/"),
       "utf-8",
     );
     expect(source).toMatch(/sanitizeInput\(.*"skill_instruction"\)/);
@@ -345,7 +346,7 @@ describe("skills/loader.ts content validation", () => {
   it("logs warnings when content is modified", async () => {
     const fs = await import("fs");
     const source = fs.readFileSync(
-      new URL("../skills/loader.ts", import.meta.url).pathname.replace("/src/__tests__/../", "/src/"),
+      fileURLToPath(new URL("../skills/loader.ts", import.meta.url)).replace(/[\\/]src[\\/]__tests__[\\/]\.\.[\\/]/, "/src/"),
       "utf-8",
     );
     expect(source).toMatch(/logger\.warn.*instruction content modified/);


### PR DESCRIPTION
## Summary
Fixes #350 by properly decoding percent-encoded characters (e.g., %20 for spaces) when resolving file paths across test suites.

## Root Cause
Accessing .pathname directly on a URL instance leaves URL percent-encodings intact. When the repository resides in a directory with spaces in its path, Node's fs functions fail with an ENOENT error.

## Changes
Replaced direct .pathname string access with fileURLToPath from node:url in command-injection and skills-hardening test files.

## Related Issues
Closes #350