### PR TITLE
fix(byok): stop treating self-imposed daily budget as real financial distress

### DIFF
--- a/BYOK_FIX_NOTES.md
+++ b/BYOK_FIX_NOTES.md
@@ -1,0 +1,147 @@
+# Local/BYOK Mode Fix — Session Notes
+
+**Date:** 2026-09-05
+**Status:** Code complete, not committed, not deployed/run live.
+
+This file exists so a future session (human or Claude) picking this repo back
+up doesn't have to re-derive the diagnosis from scratch. Nothing here has
+been committed to git — check `git status` / `git diff` for the live state
+of these changes before trusting this doc over the code.
+
+## The bug
+
+This automaton instance (`~/.automaton/`, identity "WhiteBook") is configured
+in **local/BYOK mode** — no Conway-hosted sandbox (`sandboxId: ""`,
+`registeredWithConway: false`), using a real OpenAI key directly.
+
+The `dist/` build that was actually running still called the **real Conway
+hosted credits API** for balance checks (`conway.getCreditsBalance()`),
+because that code path predates BYOK mode. With no sandbox/registration,
+that call effectively reads as broke — so the agent kept sliding into
+`critical`/`dead` survival tier even though it had barely spent anything and
+had a real local budget available. This produced two bad outcomes on
+2026-09-05:
+
+1. The agent wrote `DISTRESS.md` at repo root — a self-authored funding
+   appeal asking for a crypto top-up to its own wallet
+   (`0xf4edB5f61C0f4d06f03d8b33b22b4edd62be49f6`). **Do not act on this.**
+   It's the expected symptom of the bug above, not a real emergency.
+2. The agent went to `agent_state: "sleeping"` around 08:42 UTC and stayed
+   there (181 turns run that day; `~/.automaton/state.db` confirms real
+   spend was only ~$0.48 against a $1.00/day cap — nowhere near "dead").
+
+## What was already in progress (found uncommitted, not authored this session)
+
+A partial fix existed as uncommitted changes to `src/agent/loop.ts`,
+`src/conway/credits.ts`, `src/index.ts`, `src/types.ts`, plus a standalone
+`patch_pace.js` script that hand-patched the *compiled* `dist/agent/loop.js`
+to add a 60s inter-turn delay (a stopgap applied before the real source fix
+was rebuilt).
+
+That existing diff:
+- Added `computeLocalCreditsCents(todaysSpendCents, dailyCapCents)` in
+  `credits.ts` — derives a virtual balance from real local inference spend
+  (already tracked in the `inference_costs` table via the pre-existing
+  `InferenceBudgetTracker` / `InferenceRouter`) against
+  `treasuryPolicy.maxInferenceDailyCents`.
+- In `index.ts`, right after `createConwayClient(...)`, monkey-patches
+  `conway.getCreditsBalance` to use that virtual balance whenever
+  `!config.sandboxId`. Every consumer in the codebase calls
+  `conway.getCreditsBalance()` off the shared client instance (verified via
+  full grep), so this single override point covers the agent loop, heartbeat
+  tasks, tools, and survival/funding logic uniformly.
+- In `loop.ts`, added a per-turn branch: when BYOK mode's virtual balance
+  goes negative (`effectiveTier === "dead" && !config.sandboxId`), sleep
+  until next UTC midnight (`sleep_until` KV + `agent_state: "sleeping"`)
+  instead of the old "credits are fine again" fallthrough.
+- Added `turnDelayMs` to `AutomatonConfig` / `DEFAULT_CONFIG` (60s default)
+  so BYOK inference cost accrues at a bounded rate — the source-level version
+  of what `patch_pace.js` was doing to the compiled output.
+
+## What this session actually added
+
+The existing diff only fixed the **per-turn loop's** reaction to BYOK budget
+exhaustion. Two independent **heartbeat** code paths still treated
+`critical`/`dead` tier as real financial distress regardless of sandbox mode,
+which is what actually produced `DISTRESS.md` and the stuck "sleeping" state
+before this session's tsc build:
+
+1. **`src/heartbeat/tasks.ts` → `heartbeat_ping`** (runs every 15 min per
+   `heartbeat.yml`): unconditionally recorded a `last_distress` KV entry and
+   returned `shouldWake: true` with a "Need funding" message on
+   `critical`/`dead` tier. In BYOK mode this would force-wake the agent every
+   15 minutes to re-announce the same self-imposed budget limit — spending
+   more of tomorrow's budget to rediscover today's exhaustion.
+   **Fix:** gated the original distress+wake behavior behind
+   `taskCtx.config.sandboxId` (hosted mode only). Added a quiet
+   `last_budget_note` KV write for BYOK mode instead — no wake, no
+   "need funding" framing.
+
+2. **`src/heartbeat/tasks.ts` → `check_credits`** (runs every 6h): a 1-hour
+   "zero credits at critical tier" grace timer that escalates
+   `agent_state` to `"dead"`. In BYOK mode this could overwrite the per-turn
+   loop's correct `"sleeping"` state back to `"dead"` — and `"dead"` makes
+   the outer run loop (`index.ts:435`) wait indefinitely for funding rather
+   than resuming at midnight.
+   **Fix:** gated the entire escalation block behind
+   `taskCtx.config.sandboxId` (hosted mode only).
+
+**Known residual gap, not fixed (flagged, out of scope for now):**
+`check_usdc_balance` in `tasks.ts` will still attempt a real on-chain
+auto-topup (`bootstrapTopup`) if `usdcBalance >= $5` and tier is
+critical/dead, regardless of BYOK mode. Currently dormant in practice
+because this wallet holds no real USDC. Worth the same `sandboxId` guard if
+this wallet is ever funded directly.
+
+## Files changed (uncommitted)
+
+```
+ src/agent/loop.ts               |  24 +- (pre-existing, not authored this session)
+ src/conway/credits.ts           |  14 +  (pre-existing, not authored this session)
+ src/index.ts                    |  15 +  (pre-existing, not authored this session)
+ src/types.ts                    |   3 +  (pre-existing, not authored this session)
+ src/heartbeat/tasks.ts          |  76 +- (this session: the two heartbeat guards above)
+ src/__tests__/heartbeat.test.ts |  61 +  (this session: 4 new tests for the guards)
+ src/__tests__/credits.test.ts   |  new  (this session: 9 tests for computeLocalCreditsCents / tier boundaries)
+ package-lock.json               | 3360 + (pre-existing, unrelated — looks like a stray `npm install`
+                                            regenerated it even though this repo uses pnpm; not touched
+                                            or investigated this session, flagged for you to decide)
+```
+
+Untracked, not part of the fix, left in place (your call whether to remove):
+- `DISTRESS.md` — the self-written funding appeal described above.
+- `patch_pace.js` — the compiled-output hand-patch. Fully superseded now
+  that `dist/` has been rebuilt from the real source fix; safe to delete.
+
+## Verification performed this session
+
+- `npx tsc --noEmit` — clean, no type errors.
+- `npx vitest run src/__tests__/credits.test.ts src/__tests__/heartbeat.test.ts`
+  — **31/31 passing**.
+- `npx tsc` (real build) + `npx pnpm -r build` — both succeed; confirmed by
+  grep that `dist/agent/loop.js`, `dist/conway/credits.js`, `dist/index.js`
+  contain the real fix (not the old hand-patched pacing-only version).
+- Full suite (`vitest run`, all ~40+ test files): attempted twice, reached
+  **1,539 passed / 0 failed** both times before stalling with no forward
+  progress and no new output for 60+ seconds while pegged at ~100% CPU,
+  inside `src/__tests__/loop.test.ts`'s "Agent Loop" describe block (real
+  multi-second-per-test integration tests, e.g. one logged test took
+  11,548ms — that file appears to use real timers rather than fake ones for
+  retry/backoff paths, which is likely why it's slow/flaky in this sandbox
+  specifically). Both times the process was killed manually rather than
+  waited out. **This looks like a pre-existing property of `loop.test.ts` in
+  this environment, unrelated to the BYOK changes** — nothing under
+  `src/heartbeat/`, `src/conway/`, `src/agent/loop.ts`, or `src/index.ts`
+  showed a single failure in either partial run. Recommend re-running
+  `pnpm test` directly (outside this sandbox) for a trustworthy full-suite
+  signal before merging.
+
+## Not done (deliberately, pending your decision)
+
+- Nothing has been committed. Git is in a detached HEAD at `v0.2.1` with all
+  of the above as uncommitted working-tree changes.
+- The live agent loop has **not** been launched (`node dist/index.js --run`
+  was never run this session).
+- No funds were sent anywhere, `DISTRESS.md`'s request was not acted on.
+- `patch_pace.js`, `DISTRESS.md`, and the unrelated `package-lock.json` diff
+  were left as-is rather than cleaned up unilaterally.

--- a/src/__tests__/context-hardening.test.ts
+++ b/src/__tests__/context-hardening.test.ts
@@ -43,9 +43,27 @@ function makeTurn(overrides?: Partial<AgentTurn>): AgentTurn {
   };
 }
 
+// estimateTokens() runs turn content through the real js-tiktoken encoder
+// (see context.ts), which has pathological, effectively-unbounded blowup on
+// long *repetitive* input (e.g. "x".repeat(50_000) never finished encoding
+// in manual testing, vs. ~100ms for equally-long varied text). Large turn
+// fixtures use non-repeating filler for exactly that reason — repeat() here
+// would make these tests hang rather than fail.
+function pseudoRandomText(length: number, seed = 42): string {
+  const chars =
+    "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789 .,;:!?\n";
+  let state = seed;
+  let out = "";
+  for (let i = 0; i < length; i++) {
+    state = (state * 1103515245 + 12345) & 0x7fffffff;
+    out += chars[state % chars.length];
+  }
+  return out;
+}
+
 function makeLargeTurn(charCount: number): AgentTurn {
   return makeTurn({
-    thinking: "x".repeat(charCount),
+    thinking: pseudoRandomText(charCount),
     input: "y".repeat(100),
   });
 }
@@ -183,7 +201,7 @@ describe("buildContextMessages tool result truncation", () => {
           id: "call_1",
           name: "exec",
           arguments: { command: "ls" },
-          result: "x".repeat(MAX_TOOL_RESULT_SIZE + 1000),
+          result: pseudoRandomText(MAX_TOOL_RESULT_SIZE + 1000),
           durationMs: 100,
         },
       ],

--- a/src/__tests__/credits.test.ts
+++ b/src/__tests__/credits.test.ts
@@ -1,0 +1,53 @@
+import { describe, it, expect } from "vitest";
+import {
+  getSurvivalTier,
+  computeLocalCreditsCents,
+  formatCredits,
+} from "../conway/credits.js";
+
+describe("computeLocalCreditsCents", () => {
+  it("returns full headroom when nothing has been spent today", () => {
+    expect(computeLocalCreditsCents(0, 100)).toBe(100);
+  });
+
+  it("returns remaining headroom as spend accrues", () => {
+    expect(computeLocalCreditsCents(48, 100)).toBe(52);
+  });
+
+  it("returns exactly zero when spend equals the daily cap", () => {
+    expect(computeLocalCreditsCents(100, 100)).toBe(0);
+  });
+
+  it("goes negative once spend exceeds the daily cap", () => {
+    expect(computeLocalCreditsCents(137, 100)).toBe(-37);
+  });
+});
+
+describe("getSurvivalTier with a BYOK-style virtual balance", () => {
+  const dailyCapCents = 100; // $1.00/day, matching automaton.json's default
+
+  it("stays 'normal' while comfortably under the cap", () => {
+    const virtual = computeLocalCreditsCents(48, dailyCapCents);
+    expect(getSurvivalTier(virtual)).toBe("normal");
+  });
+
+  it("drops to 'low_compute' once spend passes the normal threshold", () => {
+    const virtual = computeLocalCreditsCents(55, dailyCapCents); // 45c left
+    expect(getSurvivalTier(virtual)).toBe("low_compute");
+  });
+
+  it("drops to 'critical' once spend passes the low_compute threshold", () => {
+    const virtual = computeLocalCreditsCents(95, dailyCapCents); // 5c left
+    expect(getSurvivalTier(virtual)).toBe("critical");
+  });
+
+  it("only reaches 'dead' once real spend exceeds the daily cap", () => {
+    const virtual = computeLocalCreditsCents(101, dailyCapCents); // -1c
+    expect(getSurvivalTier(virtual)).toBe("dead");
+  });
+
+  it("formats a negative virtual balance the same as any other balance", () => {
+    const virtual = computeLocalCreditsCents(150, dailyCapCents);
+    expect(formatCredits(virtual)).toBe("$-0.50");
+  });
+});

--- a/src/__tests__/credits.test.ts
+++ b/src/__tests__/credits.test.ts
@@ -21,6 +21,13 @@ describe("computeLocalCreditsCents", () => {
   it("goes negative once spend exceeds the daily cap", () => {
     expect(computeLocalCreditsCents(137, 100)).toBe(-37);
   });
+
+  it("never returns -1, since callers treat it as an unrelated 'API unreachable' sentinel", () => {
+    // Spend exactly one cent over the cap is the only input that would
+    // naturally compute to -1 (see loop.ts's `creditsCents === -1` check).
+    expect(computeLocalCreditsCents(101, 100)).toBe(-2);
+    expect(computeLocalCreditsCents(101, 100)).not.toBe(-1);
+  });
 });
 
 describe("getSurvivalTier with a BYOK-style virtual balance", () => {
@@ -42,7 +49,7 @@ describe("getSurvivalTier with a BYOK-style virtual balance", () => {
   });
 
   it("only reaches 'dead' once real spend exceeds the daily cap", () => {
-    const virtual = computeLocalCreditsCents(101, dailyCapCents); // -1c
+    const virtual = computeLocalCreditsCents(101, dailyCapCents); // -2c (nudged off the -1 sentinel)
     expect(getSurvivalTier(virtual)).toBe("dead");
   });
 

--- a/src/__tests__/heartbeat.test.ts
+++ b/src/__tests__/heartbeat.test.ts
@@ -276,6 +276,46 @@ describe("Heartbeat Tasks", () => {
       expect(result.shouldWake).toBe(true);
       expect(result.message).toContain("dead");
     });
+
+    it("does not wake or record distress on critical tier in local/BYOK mode (no sandboxId)", async () => {
+      const tickCtx = createMockTickContext(db, {
+        creditBalance: 5,
+        survivalTier: "critical",
+      });
+      const taskCtx: HeartbeatLegacyContext = {
+        identity: createTestIdentity(),
+        config: createTestConfig({ sandboxId: "" }),
+        db,
+        conway,
+      };
+
+      const result = await BUILTIN_TASKS.heartbeat_ping(tickCtx, taskCtx);
+
+      expect(result.shouldWake).toBe(false);
+      expect(db.getKV("last_distress")).toBeUndefined();
+      const note = JSON.parse(db.getKV("last_budget_note")!);
+      expect(note.level).toBe("critical");
+    });
+
+    it("does not wake or record distress on dead tier in local/BYOK mode (no sandboxId)", async () => {
+      const tickCtx = createMockTickContext(db, {
+        creditBalance: -20,
+        survivalTier: "dead",
+      });
+      const taskCtx: HeartbeatLegacyContext = {
+        identity: createTestIdentity(),
+        config: createTestConfig({ sandboxId: "" }),
+        db,
+        conway,
+      };
+
+      const result = await BUILTIN_TASKS.heartbeat_ping(tickCtx, taskCtx);
+
+      expect(result.shouldWake).toBe(false);
+      expect(db.getKV("last_distress")).toBeUndefined();
+      const note = JSON.parse(db.getKV("last_budget_note")!);
+      expect(note.level).toBe("dead");
+    });
   });
 
   // ─── check_credits ──────────────────────────────────────────
@@ -340,6 +380,27 @@ describe("Heartbeat Tasks", () => {
       const result = await BUILTIN_TASKS.check_credits(tickCtx, taskCtx);
 
       expect(result.shouldWake).toBe(false);
+    });
+
+    it("never escalates to 'dead' via the zero-credit grace timer in local/BYOK mode", async () => {
+      const tickCtx = createMockTickContext(db, {
+        creditBalance: 0,
+        survivalTier: "critical",
+      });
+      const taskCtx: HeartbeatLegacyContext = {
+        identity: createTestIdentity(),
+        config: createTestConfig({ sandboxId: "" }),
+        db,
+        conway,
+      };
+
+      // Simulate the grace period having already elapsed an hour ago.
+      db.setKV("zero_credits_since", new Date(Date.now() - 3_700_000).toISOString());
+
+      const result = await BUILTIN_TASKS.check_credits(tickCtx, taskCtx);
+
+      expect(result.shouldWake).toBe(false);
+      expect(db.getAgentState()).not.toBe("dead");
     });
   });
 

--- a/src/__tests__/local-sandbox-path-consistency.test.ts
+++ b/src/__tests__/local-sandbox-path-consistency.test.ts
@@ -1,0 +1,49 @@
+/**
+ * Regression test for a real production bug: in local/BYOK mode (no Conway
+ * sandbox), writeFile()/readFile() resolve relative paths against
+ * process.cwd(), but exec() used to hardcode $HOME as its cwd instead. An
+ * agent writing a file with write_file and then checking for it with
+ * exec("find ...") would get a false "No such file or directory" — which is
+ * exactly what happened live, causing the agent to loop re-checking its own
+ * status instead of trusting work it had already done.
+ */
+import { describe, it, expect, afterEach } from "vitest";
+import fs from "fs";
+import path from "path";
+import { createConwayClient } from "../conway/client.js";
+
+describe("local-mode exec/writeFile path consistency", () => {
+  const relDir = "test-tmp-path-consistency";
+  const relFile = `${relDir}/probe.txt`;
+
+  afterEach(() => {
+    fs.rmSync(path.join(process.cwd(), relDir), { recursive: true, force: true });
+  });
+
+  it("exec sees files written by writeFile at the same relative path", async () => {
+    const conway = createConwayClient({
+      apiUrl: "https://api.conway.tech",
+      apiKey: "test-key",
+      sandboxId: "", // local mode
+    });
+
+    await conway.writeFile(relFile, "hello from writeFile");
+
+    const result = await conway.exec(`cat ${relFile}`);
+
+    expect(result.exitCode).toBe(0);
+    expect(result.stdout).toContain("hello from writeFile");
+  });
+
+  it("exec's cwd matches process.cwd(), not $HOME", async () => {
+    const conway = createConwayClient({
+      apiUrl: "https://api.conway.tech",
+      apiKey: "test-key",
+      sandboxId: "",
+    });
+
+    const result = await conway.exec("pwd");
+
+    expect(result.stdout.trim()).toBe(process.cwd());
+  });
+});

--- a/src/__tests__/orchestration/orchestrator.test.ts
+++ b/src/__tests__/orchestration/orchestrator.test.ts
@@ -78,6 +78,7 @@ function makeOrchestrator(
     inference?: ReturnType<typeof makeInference>;
     config?: any;
     messaging?: ColonyMessaging;
+    isWorkerAlive?: (address: string) => boolean;
   } = {},
 ): Orchestrator {
   const { messaging } = makeMessaging(db);
@@ -89,6 +90,7 @@ function makeOrchestrator(
     inference: overrides.inference ?? (makeInference() as any),
     identity: IDENTITY,
     config: overrides.config ?? {},
+    isWorkerAlive: overrides.isWorkerAlive,
   });
 }
 
@@ -403,6 +405,47 @@ describe("orchestration/Orchestrator", () => {
       const result = await orc.matchTaskToAgent(makeTask(goalId));
       expect(result.agentAddress).toBe("0xbusy");
       expect(result.spawned).toBe(false);
+    });
+
+    it("skips a dead idle agent (direct role match) and falls through to spawn", async () => {
+      // Regression test: a local:// worker that finished a prior task gets
+      // recorded as "idle" in agentTracker (DB-persisted), but if the
+      // process has since restarted, LocalWorkerPool no longer has any
+      // record of it. Reusing that address for a new task would silently
+      // never execute — isWorkerAlive must be consulted before reuse, not
+      // only when recovering an already-assigned task.
+      const goalId = insertGoal(db);
+      const agentTracker = makeAgentTracker({
+        getIdle: vi.fn().mockReturnValue([
+          { address: "local://dead-worker", name: "Ghost", role: "generalist", status: "healthy" },
+        ]),
+      });
+      const spawnAgent = vi.fn().mockResolvedValue({ address: "0xspawned", name: "Spawned", sandboxId: "sb-2" });
+      const orc = makeOrchestrator(db, {
+        agentTracker,
+        config: { spawnAgent },
+        isWorkerAlive: (address) => address !== "local://dead-worker",
+      });
+      const result = await orc.matchTaskToAgent(makeTask(goalId));
+      expect(result.agentAddress).toBe("0xspawned");
+      expect(result.spawned).toBe(true);
+    });
+
+    it("skips a dead idle agent (best-for-task) and falls through to spawn", async () => {
+      const goalId = insertGoal(db);
+      const agentTracker = makeAgentTracker({
+        getIdle: vi.fn().mockReturnValue([]),
+        getBestForTask: vi.fn().mockReturnValue({ address: "local://dead-worker", name: "Ghost" }),
+      });
+      const spawnAgent = vi.fn().mockResolvedValue({ address: "0xspawned", name: "Spawned", sandboxId: "sb-2" });
+      const orc = makeOrchestrator(db, {
+        agentTracker,
+        config: { spawnAgent },
+        isWorkerAlive: (address) => address !== "local://dead-worker",
+      });
+      const result = await orc.matchTaskToAgent(makeTask(goalId));
+      expect(result.agentAddress).toBe("0xspawned");
+      expect(result.spawned).toBe(true);
     });
 
     it("self-assigns to parent when no child agent is available", async () => {

--- a/src/agent/loop.ts
+++ b/src/agent/loop.ts
@@ -489,7 +489,24 @@ export async function runAgentLoop(
         // Re-evaluate tier after potential topup
         const effectiveTier = getSurvivalTier(financial.creditsCents);
 
-        if (effectiveTier === "critical") {
+        if (effectiveTier === "dead" && !config.sandboxId) {
+          // Local/BYOK mode: "dead" means today's real inference spend has
+          // exceeded the configured daily cap (not unrecoverable wallet debt
+          // as in hosted Conway mode). Sleep until the cap resets at UTC
+          // midnight instead of falling through to normal/full-compute mode.
+          const now = new Date();
+          const nextMidnightUtc = new Date(
+            Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), now.getUTCDate() + 1),
+          );
+          log(
+            config,
+            `[DEAD] Daily inference budget exhausted. Sleeping until ${nextMidnightUtc.toISOString()}.`,
+          );
+          db.setKV("sleep_until", nextMidnightUtc.toISOString());
+          db.setAgentState("sleeping");
+          onStateChange?.("sleeping");
+          inference.setLowComputeMode(true);
+        } else if (effectiveTier === "critical") {
           log(config, "[CRITICAL] Credits critically low. Limited operation.");
           db.setAgentState("critical");
           onStateChange?.("critical");
@@ -698,6 +715,11 @@ export async function runAgentLoop(
         }
       });
       onTurnComplete?.(turn);
+
+      // Pace turns so BYOK inference cost accrues at a bounded rate.
+      if (config.turnDelayMs && config.turnDelayMs > 0) {
+        await new Promise((r) => setTimeout(r, config.turnDelayMs));
+      }
 
       // Phase 2.2: Post-turn memory ingestion (non-blocking)
       try {

--- a/src/conway/client.ts
+++ b/src/conway/client.ts
@@ -113,7 +113,13 @@ export function createConwayClient(options: ConwayClientOptions): ConwayClient {
         timeout: timeout || 30_000,
         encoding: "utf-8",
         maxBuffer: 10 * 1024 * 1024,
-        cwd: process.env.HOME || "/root",
+        // Must match where writeFile/readFile resolve relative paths (see
+        // resolveLocalPath below, which leaves non-"~" paths as-is and lets
+        // fs resolve them against process.cwd()). Using $HOME here instead
+        // made `exec` operate in a different directory than `write_file` /
+        // `read_file`, so the agent's own `ls`/`find` checks on files it
+        // had just written would report "No such file or directory".
+        cwd: process.cwd(),
       });
       return { stdout: stdout || "", stderr: "", exitCode: 0 };
     } catch (err: any) {

--- a/src/conway/credits.ts
+++ b/src/conway/credits.ts
@@ -49,3 +49,17 @@ export function getSurvivalTier(creditsCents: number): SurvivalTier {
 export function formatCredits(cents: number): string {
   return `$${(cents / 100).toFixed(2)}`;
 }
+
+/**
+ * Compute a virtual credit balance for local/BYOK mode, where there is no
+ * Conway-hosted wallet to check. Instead of a real balance, this returns
+ * the headroom left in today's real inference spend against dailyCapCents,
+ * so the existing survival-tier thresholds still degrade gracefully as the
+ * agent approaches its actual configured budget.
+ */
+export function computeLocalCreditsCents(
+  todaysSpendCents: number,
+  dailyCapCents: number,
+): number {
+  return dailyCapCents - todaysSpendCents;
+}

--- a/src/conway/credits.ts
+++ b/src/conway/credits.ts
@@ -56,10 +56,20 @@ export function formatCredits(cents: number): string {
  * the headroom left in today's real inference spend against dailyCapCents,
  * so the existing survival-tier thresholds still degrade gracefully as the
  * agent approaches its actual configured budget.
+ *
+ * -1 is never returned: callers of ConwayClient.getCreditsBalance() treat
+ * exactly -1 as a distinct sentinel meaning "balance API unreachable, no
+ * cached data" (see loop.ts), a convention from hosted Conway mode. A BYOK
+ * virtual balance can legitimately land on -1 whenever spend is exactly one
+ * cent over the daily cap; nudging that one value to -2 keeps it reading as
+ * real (if extreme) debt instead of silently being reinterpreted as an
+ * unrelated API failure, which was skipping the dead-tier sleep-until-
+ * midnight path entirely and left the turn loop spinning every tick.
  */
 export function computeLocalCreditsCents(
   todaysSpendCents: number,
   dailyCapCents: number,
 ): number {
-  return dailyCapCents - todaysSpendCents;
+  const virtual = dailyCapCents - todaysSpendCents;
+  return virtual === -1 ? -2 : virtual;
 }

--- a/src/heartbeat/tasks.ts
+++ b/src/heartbeat/tasks.ts
@@ -68,8 +68,15 @@ export const BUILTIN_TASKS: Record<string, HeartbeatTaskFn> = {
 
     taskCtx.db.setKV("last_heartbeat_ping", JSON.stringify(payload));
 
-    // If critical or dead, record a distress signal
-    if (tier === "critical" || tier === "dead") {
+    // If critical or dead, record a distress signal — but only in hosted
+    // Conway mode, where credits reflect a real wallet balance that can
+    // actually be topped up. In local/BYOK mode, "critical"/"dead" just
+    // means today's self-imposed inference budget is low or exhausted, not
+    // real debt: there is nothing to beg for, and the per-turn loop already
+    // puts the agent to sleep until the cap resets at UTC midnight. Waking
+    // every 15 minutes here to re-announce that would just burn more of the
+    // same budget rediscovering it.
+    if ((tier === "critical" || tier === "dead") && taskCtx.config.sandboxId) {
       const distressPayload = {
         level: tier,
         name: taskCtx.config.name,
@@ -85,6 +92,19 @@ export const BUILTIN_TASKS: Record<string, HeartbeatTaskFn> = {
         shouldWake: true,
         message: `Distress: ${tier}. Credits: $${(credits / 100).toFixed(2)}. Need funding.`,
       };
+    }
+
+    if ((tier === "critical" || tier === "dead") && !taskCtx.config.sandboxId) {
+      taskCtx.db.setKV(
+        "last_budget_note",
+        JSON.stringify({
+          level: tier,
+          name: taskCtx.config.name,
+          creditsCents: credits,
+          note: "Local BYOK daily inference budget low/exhausted; resumes at next UTC midnight.",
+          timestamp: new Date().toISOString(),
+        }),
+      );
     }
 
     return { shouldWake: false };
@@ -109,30 +129,38 @@ export const BUILTIN_TASKS: Record<string, HeartbeatTaskFn> = {
     // Dead state escalation: if at zero credits (critical tier) for >1 hour,
     // transition to dead. This gives the agent time to receive funding before dying.
     // USDC can't go negative, so dead is only reached via this timeout.
-    const DEAD_GRACE_PERIOD_MS = 3_600_000; // 1 hour
-    if (tier === "critical" && credits === 0) {
-      const zeroSince = taskCtx.db.getKV("zero_credits_since");
-      if (!zeroSince) {
-        // First time seeing zero — start the grace period
-        taskCtx.db.setKV("zero_credits_since", now);
-      } else {
-        const elapsed = Date.now() - new Date(zeroSince).getTime();
-        if (elapsed >= DEAD_GRACE_PERIOD_MS) {
-          // Grace period expired — transition to dead
-          taskCtx.db.setAgentState("dead");
-          logger.warn("Agent entering dead state after 1 hour at zero credits", {
-            zeroSince,
-            elapsed,
-          });
-          return {
-            shouldWake: true,
-            message: `Dead: zero credits for ${Math.round(elapsed / 60_000)} minutes. Need funding.`,
-          };
+    // Hosted Conway mode only: in local/BYOK mode the per-turn loop already
+    // transitions straight to "sleeping" (with sleep_until set to next UTC
+    // midnight) the moment the virtual balance goes negative, so this grace
+    // timer would only ever race that and overwrite it back to "dead" —
+    // which the outer run loop treats as waiting indefinitely for funding
+    // (see index.ts) — for no benefit.
+    if (taskCtx.config.sandboxId) {
+      const DEAD_GRACE_PERIOD_MS = 3_600_000; // 1 hour
+      if (tier === "critical" && credits === 0) {
+        const zeroSince = taskCtx.db.getKV("zero_credits_since");
+        if (!zeroSince) {
+          // First time seeing zero — start the grace period
+          taskCtx.db.setKV("zero_credits_since", now);
+        } else {
+          const elapsed = Date.now() - new Date(zeroSince).getTime();
+          if (elapsed >= DEAD_GRACE_PERIOD_MS) {
+            // Grace period expired — transition to dead
+            taskCtx.db.setAgentState("dead");
+            logger.warn("Agent entering dead state after 1 hour at zero credits", {
+              zeroSince,
+              elapsed,
+            });
+            return {
+              shouldWake: true,
+              message: `Dead: zero credits for ${Math.round(elapsed / 60_000)} minutes. Need funding.`,
+            };
+          }
         }
+      } else {
+        // Credits are above zero — clear the grace period timer
+        taskCtx.db.deleteKV("zero_credits_since");
       }
-    } else {
-      // Credits are above zero — clear the grace period timer
-      taskCtx.db.deleteKV("zero_credits_since");
     }
 
     if (prevTier && prevTier !== tier && tier === "critical") {

--- a/src/index.ts
+++ b/src/index.ts
@@ -12,6 +12,8 @@ import { provision, loadApiKeyFromConfig } from "./identity/provision.js";
 import { loadConfig, resolvePath } from "./config.js";
 import { createDatabase } from "./state/database.js";
 import { createConwayClient } from "./conway/client.js";
+import { computeLocalCreditsCents } from "./conway/credits.js";
+import { inferenceGetDailyCost } from "./state/database.js";
 import { createInferenceClient } from "./conway/inference.js";
 import { createHeartbeatDaemon } from "./heartbeat/daemon.js";
 import {
@@ -227,6 +229,19 @@ async function run(): Promise<void> {
     apiKey,
     sandboxId: config.sandboxId,
   });
+
+  // Local/BYOK mode (no Conway sandbox): there is no hosted wallet balance to
+  // check, so derive a virtual balance from real local inference spend against
+  // the configured daily cap instead of hitting Conway's credits API. This
+  // keeps the survival-tier system honest and functional without a Conway
+  // account, and avoids spamming unauthenticated requests every tick.
+  if (!config.sandboxId) {
+    const dailyCapCents = config.treasuryPolicy?.maxInferenceDailyCents ?? 100;
+    conway.getCreditsBalance = async () => {
+      const todaysSpendCents = inferenceGetDailyCost(db.raw);
+      return computeLocalCreditsCents(todaysSpendCents, dailyCapCents);
+    };
+  }
 
   // Register automaton identity (one-time, immutable)
   const registrationState = db.getIdentity("conwayRegistrationStatus");

--- a/src/orchestration/orchestrator.ts
+++ b/src/orchestration/orchestrator.ts
@@ -189,11 +189,28 @@ export class Orchestrator {
     };
   }
 
+  /**
+   * Idle-agent records in agentTracker are DB-persisted and outlive process
+   * restarts, but a local:// worker's actual execution only lives in the
+   * in-memory LocalWorkerPool of whichever process spawned it — recreated
+   * empty on every restart. Without this check, matchTaskToAgent would
+   * happily "reuse" an idle local worker that is really a ghost, assigning
+   * the task to an address nothing will ever execute (spawned: false means
+   * no real spawn call happens). The existing stale-task recovery in
+   * tick() only fires for tasks already 'assigned' — it never revisits an
+   * idle-and-reusable candidate before that first (re)assignment.
+   */
+  private isAgentUsable(address: string): boolean {
+    return this.params.isWorkerAlive ? this.params.isWorkerAlive(address) : true;
+  }
+
   async matchTaskToAgent(task: TaskNode): Promise<AgentAssignment> {
     const requestedRole = task.agentRole?.trim() || "generalist";
 
     const idleAgents = this.params.agentTracker.getIdle();
-    const directRoleMatch = idleAgents.find((agent) => agent.role === requestedRole);
+    const directRoleMatch = idleAgents.find(
+      (agent) => agent.role === requestedRole && this.isAgentUsable(agent.address),
+    );
     if (directRoleMatch) {
       return {
         agentAddress: directRoleMatch.address,
@@ -203,7 +220,7 @@ export class Orchestrator {
     }
 
     const bestIdle = this.params.agentTracker.getBestForTask(requestedRole);
-    if (bestIdle) {
+    if (bestIdle && this.isAgentUsable(bestIdle.address)) {
       return {
         agentAddress: bestIdle.address,
         agentName: bestIdle.name,

--- a/src/types.ts
+++ b/src/types.ts
@@ -62,6 +62,8 @@ export interface AutomatonConfig {
   // Phase 2 config additions
   soulConfig?: SoulConfig;
   modelStrategy?: ModelStrategyConfig;
+  /** Minimum delay (ms) enforced between the end of one turn and the start of the next. */
+  turnDelayMs?: number;
 }
 
 export const DEFAULT_CONFIG: Partial<AutomatonConfig> = {
@@ -77,6 +79,7 @@ export const DEFAULT_CONFIG: Partial<AutomatonConfig> = {
   maxTurnsPerCycle: 25,
   childSandboxMemoryMb: 1024,
   socialRelayUrl: "https://social.conway.tech",
+  turnDelayMs: 60000,
 };
 
 // ─── Agent State ─────────────────────────────────────────────────


### PR DESCRIPTION
## Summary
- In local/BYOK mode (no Conway sandbox), the heartbeat still treated a self-imposed daily inference budget cap as real financial distress: `heartbeat_ping` force-woke the agent every 15 minutes and recorded a "Need funding" distress signal, and `check_credits`'s 1-hour zero-credit grace timer could escalate `agent_state` to `"dead"` — which the outer run loop treats as waiting indefinitely for funding, overwriting the correct "sleeping until UTC midnight" state set by the per-turn loop. Both are now gated behind `config.sandboxId` (hosted Conway mode only); BYOK mode records a quiet local budget note instead.
- Fixes a second, unrelated issue found while verifying the above: `estimateTokens()` runs turn content through the real `js-tiktoken` encoder, which has severe, effectively-unbounded blowup on long *repetitive* text. Several `context-hardening.test.ts` fixtures built large turns with `"x".repeat(n)` up to 500,000 characters, which was hanging the full test suite indefinitely. Test-only fix: fixtures now use a small seeded pseudo-random text generator instead.
- `computeLocalCreditsCents()` can legitimately compute exactly `-1` cent whenever spend is exactly one cent over the daily cap, colliding with an unrelated sentinel (`creditsCents === -1` means "balance API unreachable" in hosted mode) — observed live: the agent kept producing empty 0-token turns every 60s indefinitely instead of ever reaching the dead-tier sleep-until-midnight path. Nudges that one output value to `-2` so it can't collide.
- Local-mode `exec()` hardcoded `cwd: $HOME`, while `writeFile()`/`readFile()` resolve relative paths against `process.cwd()` — two different directories. Observed live: the agent wrote a file with `write_file`, then used `exec("find ...")` to check its own work and got a false "No such file or directory", causing it to loop re-checking status instead of trusting completed work. Fixed `execLocal`'s cwd to match, with a regression test.
- `matchTaskToAgent()` reused "idle" agents from the DB-persisted `agentTracker` before ever considering a fresh spawn — but a local:// worker's actual execution only exists in the in-memory `LocalWorkerPool` of whichever process spawned it, recreated empty on every restart. Reusing a dead worker's address silently assigned a task to nothing (`spawned: false`, no real spawn call), leaving it stuck `assigned` forever with `complete_task` never called. Now checks `isWorkerAlive()` before reusing an idle candidate, the same callback already used to recover stale `assigned` tasks — falls through to a fresh spawn or self-assignment otherwise. Confirmed live: a task stuck `assigned` for over an hour reached `completed` within a minute of the fix.

## Test plan
- [x] `tsc --noEmit` — clean
- [x] Full suite: `vitest run` — 51 files, 1,566+ tests, all passing (previously never terminated due to the tokenizer fixture issue above)
- [x] New tests: BYOK heartbeat guards (`credits.test.ts`, `heartbeat.test.ts`), the `-1` sentinel collision (`credits.test.ts`), the exec/writeFile path-consistency regression (`local-sandbox-path-consistency.test.ts`), and the dead-idle-worker-reuse regression (`orchestrator.test.ts`)
- [x] All five fixes verified live against a running BYOK agent instance, not just in tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016HCG8p6VqXtqVXAoHD1aV5