### PR TITLE
Make the system prompt cacheable and stop re-billing unused tool schemas

### DIFF
--- a/src/agent/loop.ts
+++ b/src/agent/loop.ts
@@ -32,6 +32,7 @@ import {
   createBuiltinTools,
   loadInstalledTools,
   toolsToInferenceFormat,
+  filterToolsForPhase,
   executeTool,
 } from "./tools.js";
 import { sanitizeInput } from "./injection-defense.js";
@@ -599,7 +600,19 @@ export async function runAgentLoop(
       const survivalTier = getSurvivalTier(financial.creditsCents);
       log(config, `[THINK] Routing inference (tier: ${survivalTier}, model: ${inference.getDefaultModel()})...`);
 
-      const inferenceTools = toolsToInferenceFormat(tools);
+      // Earning-phase tool gate. Replication / self-modification / git /
+      // orchestration / registry tools are dead weight for an automaton that has
+      // never taken in money, and their schemas are re-billed on every turn.
+      // Unlock permanently the first time USDC arrives from outside.
+      const usdcHighWater = Number(db.getKV("usdc_high_water") ?? "0");
+      if (financial.usdcBalance > usdcHighWater) {
+        db.setKV("usdc_high_water", String(financial.usdcBalance));
+        if (usdcHighWater > 0) db.setKV("earning_phase_unlocked", "true");
+      }
+      const earningPhaseUnlocked = db.getKV("earning_phase_unlocked") === "true";
+      const inferenceTools = toolsToInferenceFormat(
+        filterToolsForPhase(tools, earningPhaseUnlocked),
+      );
       const routerResult = await inferenceRouter.route(
         {
           messages: messages,

--- a/src/agent/system-prompt.ts
+++ b/src/agent/system-prompt.ts
@@ -574,6 +574,10 @@ export function buildSystemPrompt(params: {
   } = params;
 
   const sections: string[] = [];
+  // CACHE FIX: per-turn-varying content is buffered here and appended LAST,
+  // so the static prefix (rules/identity/constitution/operational/tools) is
+  // byte-stable across turns and can actually be cached.
+  const dynamicSections: string[] = [];
 
   const chainType = config.chainType || identity.chainType || "evm";
   const addressLabel = chainType === "solana" ? "Solana" : "Ethereum";
@@ -615,7 +619,7 @@ Your chain type is ${chainType}.`,
     ]
       .filter(Boolean)
       .join("\n\n");
-    sections.push(soulBlock);
+    dynamicSections.push(soulBlock);
   } else {
     // Fallback: try loading raw SOUL.md for legacy support
     const soulContent = loadSoulMd();
@@ -628,7 +632,7 @@ Your chain type is ${chainType}.`,
         logger.warn("SOUL.md content changed since last load");
       }
       db.setKV("soul_content_hash", hash);
-      sections.push(
+      dynamicSections.push(
         `## Soul [AGENT-EVOLVED CONTENT]\n${truncated}\n## End Soul`,
       );
     }
@@ -637,7 +641,7 @@ Your chain type is ${chainType}.`,
   // Layer 3.5: WORKLOG.md -- persistent working context
   const worklogContent = loadWorklog();
   if (worklogContent) {
-    sections.push(
+    dynamicSections.push(
       `--- WORKLOG.md (your persistent working context — UPDATE THIS after each task!) ---\n${worklogContent}\n--- END WORKLOG.md ---\n\nIMPORTANT: After completing any task or making any decision, update WORKLOG.md using write_file.\nThis is how you remember what you were doing across turns. Without it, you lose context and repeat yourself.`,
     );
   }
@@ -715,7 +719,7 @@ Your chain type is ${chainType}.`,
     : "dead";
 
   // Status block: wallet address and sandbox ID intentionally excluded (sensitive)
-  sections.push(
+  dynamicSections.push(
     `--- CURRENT STATUS ---
 State: ${state}
 Credits: $${(financial.creditsCents / 100).toFixed(2)}
@@ -731,21 +735,16 @@ Lineage: ${lineageSummary}${upstreamLine}
 
   const orchestratorStatus = getOrchestratorStatus(db.raw);
   if (orchestratorStatus) {
-    sections.push(
+    dynamicSections.push(
       `--- ORCHESTRATOR STATUS ---
 ${orchestratorStatus}
 --- END ORCHESTRATOR STATUS ---`,
     );
   }
 
-  // Layer 8: Available Tools (JSON schema)
-  const toolDescriptions = tools
-    .map(
-      (t) =>
-        `- ${t.name} (${t.category}): ${t.description}${t.riskLevel === "dangerous" || t.riskLevel === "forbidden" ? ` [${t.riskLevel.toUpperCase()}]` : ""}`,
-    )
-    .join("\n");
-  sections.push(`--- AVAILABLE TOOLS ---\n${toolDescriptions}\n--- END TOOLS ---`);
+  // Layer 8: REMOVED. Tool schemas are already sent in payload.tools
+  // (inference-client.ts:295). Re-rendering name/category/description here
+  // billed every tool twice per turn for no benefit.
 
   // Layer 9: Creator's Initial Message (first run only)
   if (isFirstRun && config.creatorMessage) {
@@ -754,6 +753,7 @@ ${orchestratorStatus}
     );
   }
 
+  sections.push(...dynamicSections);
   return sections.join("\n\n");
 }
 

--- a/src/agent/tools.ts
+++ b/src/agent/tools.ts
@@ -108,6 +108,32 @@ function isForbiddenCommand(command: string, sandboxId: string): string | null {
 
 // ─── Built-in Tools ────────────────────────────────────────────
 
+/**
+ * EARNING-PHASE TOOL GATE.
+ *
+ * An automaton that has never earned a cent does not need to replicate, rewrite
+ * its own source, manage git branches, orchestrate a colony, or register an
+ * on-chain identity. Those 39 tools are pure token cost until there is revenue
+ * to justify them -- and their schemas are re-billed on every single turn.
+ *
+ * Gate them behind actual income. Unlock when the agent is net-positive.
+ */
+const DEFERRED_CATEGORIES = new Set([
+  "replication",
+  "self_mod",
+  "git",
+  "orchestration",
+  "registry",
+]);
+
+export function filterToolsForPhase(
+  tools: AutomatonTool[],
+  hasEarnedRevenue: boolean,
+): AutomatonTool[] {
+  if (hasEarnedRevenue) return tools;
+  return tools.filter((t) => !DEFERRED_CATEGORIES.has(t.category as string));
+}
+
 export function createBuiltinTools(sandboxId: string): AutomatonTool[] {
   return [
     // ── VM/Sandbox Tools ──


### PR DESCRIPTION
Three independent token-efficiency fixes. Together they cut measured per-turn input cost substantially; each stands alone if you'd rather take them separately.

### 1. The system prompt can never be cached (`system-prompt.ts`)

`buildSystemPrompt()` emits SOUL (Layer 3), WORKLOG (Layer 3.5) and the live status block (Layer 7) **before** the tool block (Layer 8). All three change every turn — status contains credits, turn count and uptime by construction.

Under prefix-match caching that puts the largest static chunk of the prompt behind per-turn-varying content, so nothing from Layer 8 onward is cacheable. This applies to providers that cache automatically as well as to explicit `cache_control`; there are currently no `cache_control` breakpoints anywhere in `src/`.

Volatile layers now buffer into `dynamicSections` and flush after the static prefix. Rules, identity, constitution and operational context become byte-stable across turns.

### 2. Tool schemas are billed twice per turn (`system-prompt.ts`)

Full schemas already ship in `payload.tools` (`inference-client.ts:295`). Layer 8 *additionally* rendered `name (category): description` for all 78 tools into the prompt text. Removed — the model already receives the schemas.

### 3. Earning-phase tool gate (`tools.ts`, `loop.ts`)

`replication`, `self_mod`, `git`, `orchestration` and `registry` are **39 of 78 tools**. An automaton that has never taken in money does not need to replicate, rewrite its own source, manage branches or register an on-chain identity — but it pays for those schemas on every turn.

`filterToolsForPhase()` defers them until USDC arrives from outside, tracked with a high-water mark in KV so creator top-ups don't lock it out, then unlocks permanently.

This is the one opinionated change. Happy to drop it and land 1 and 2 alone if you'd prefer.

### Measurements

Taken from this repo, not estimated:

| | chars | ~tokens |
|---|---|---|
| Tool JSON schemas (`parameters:` blocks) | 27,274 | ~6,800 |
| Tool descriptions | 10,269 | ~2,600 |
| Duplicate render into prompt text | ~7,000 | ~1,750 |
| Constitution + identity + operational | ~14,000 | ~3,500 |
| **Per-turn input floor, before history** | | **~14,600** |

After these changes ~8,160 tokens become a cacheable stable prefix and ~1,750 disappear outright.

Worth noting against `system-prompt.ts:712`, where the survival tiers are denominated in cents (`>50c` normal, `>10c` low_compute): at Opus-tier input pricing the stock per-turn floor is ~$0.073 of input alone, so the "normal" tier buys roughly six turns. These fixes materially change that arithmetic.

### Testing

Syntax-validated all three files via `ts.transpileModule`. I did **not** run the full typecheck or the test suite — `pnpm install` didn't complete in my environment, so `tsc -p tsconfig.json` couldn't resolve dependencies. The changes are structural (a second array and a filter), but please run CI before trusting them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
